### PR TITLE
8302879: doc/building.md update link to jtreg builds

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1087,7 +1087,7 @@ home, i.e. the top directory, containing <code>lib/jtreg.jar</code>
 etc.</p>
 <p>The <a href="https://wiki.openjdk.org/display/Adoption">Adoption
 Group</a> provides recent builds of jtreg <a
-href="https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/">here</a>.
+href="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/">here</a>.
 Download the latest <code>.tar.gz</code> file, unpack it, and point
 <code>--with-jtreg</code> to the <code>jtreg</code> directory that you
 just unpacked.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -860,7 +860,7 @@ containing `lib/jtreg.jar` etc.
 
 The [Adoption Group](https://wiki.openjdk.org/display/Adoption) provides
 recent builds of jtreg [here](
-https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/).
+https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/).
 Download the latest `.tar.gz` file, unpack it, and point `--with-jtreg` to the
 `jtreg` directory that you just unpacked.
 


### PR DESCRIPTION
The Eclipse Adoptium project recently moved its CI from ci.adoptopenjdk.net to ci.adoptium.net. The link to jtreg builds needs updating

See https://github.com/adoptium/infrastructure/issues/2932 for more context

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302879](https://bugs.openjdk.org/browse/JDK-8302879): doc/building.md update link to jtreg builds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk20u pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/8.diff">https://git.openjdk.org/jdk20u/pull/8.diff</a>

</details>
