### PR TITLE
8301876: Crash in DumpTimeClassInfo::add_verification_constraint

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1449,11 +1449,9 @@ class CloneDumpTimeClassTable: public StackObj {
     assert(_cloned_table != NULL, "_cloned_table is NULL");
   }
   void do_entry(InstanceKlass* k, DumpTimeClassInfo& info) {
-    if (!info.is_excluded()) {
-      bool created;
-      _cloned_table->put_if_absent(k, info, &created);
-      assert(created, "must be");
-    }
+    bool created;
+    _cloned_table->put_if_absent(k, info, &created);
+    assert(created, "must be");
   }
 };
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301876](https://bugs.openjdk.org/browse/JDK-8301876): Crash in DumpTimeClassInfo::add_verification_constraint


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/jdk20u pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/9.diff">https://git.openjdk.org/jdk20u/pull/9.diff</a>

</details>
