### PR TITLE
8303186: Missing Classpath exception from Continuation.c

### DIFF
--- a/src/java.base/share/native/libjava/Continuation.c
+++ b/src/java.base/share/native/libjava/Continuation.c
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [dc08216f](https://github.com/openjdk/jdk/commit/dc08216f0ef55970c96df43bcc86ebd5792d486e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tyler Steele on 2 Mar 2023 and was reviewed by David Holmes and Jaikiran Pai.

I recognize that we are in the RC stage of jdk20 release. I'd like to include this change in the first release of jdk20, as it probably should have happened in jdk19. It isn't a code change, so the risk is quite low. 

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303186](https://bugs.openjdk.org/browse/JDK-8303186): Missing Classpath exception from Continuation.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jdk20u pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/13.diff">https://git.openjdk.org/jdk20u/pull/13.diff</a>

</details>
