### PR TITLE
8303937: Corrupted heap dumps due to missing retries for os::write()

### DIFF
--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -55,10 +55,14 @@ char const* FileWriter::write_buf(char* buf, ssize_t size) {
   assert(_fd >= 0, "Must be open");
   assert(size > 0, "Must write at least one byte");
 
-  ssize_t n = os::write(_fd, buf, (uint) size);
+  while (size > 0) {
+    ssize_t n = os::write(_fd, buf, (uint) size);
+    if (n <= 0) {
+      return os::strerror(errno);
+    }
 
-  if (n <= 0) {
-    return os::strerror(errno);
+    buf += n;
+    size -= n;
   }
 
   return NULL;


### PR DESCRIPTION
No conflict backporting to 20u. I'll need a sponsor to help pushing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303937](https://bugs.openjdk.org/browse/JDK-8303937): Corrupted heap dumps due to missing retries for os::write()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jdk20u pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/18.diff">https://git.openjdk.org/jdk20u/pull/18.diff</a>

</details>
