### PR TITLE
8227257: javax/swing/JFileChooser/4847375/bug4847375.java fails with AssertionError

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -901,7 +901,7 @@ final class Win32ShellFolder2 extends ShellFolder {
                         location =
                                 Win32ShellFolderManager2.createShellFolderFromRelativePIDL(getDesktop(),
                                         linkLocationPIDL);
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException | FileNotFoundException e) {
                         // Return null
                     } catch (InternalError e) {
                         // Could be a link to a non-bindable object, such as a network connection

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,11 +108,15 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
     }
 
     static Win32ShellFolder2 createShellFolderFromRelativePIDL(Win32ShellFolder2 parent, long pIDL)
-            throws InterruptedException {
+            throws InterruptedException, FileNotFoundException
+    {
         // Walk down this relative pIDL, creating new nodes for each of the entries
         while (pIDL != 0) {
             long curPIDL = Win32ShellFolder2.copyFirstPIDLEntry(pIDL);
             if (curPIDL != 0) {
+                if (!parent.isDirectory()) {
+                    throw new FileNotFoundException("not a directory");
+                }
                 parent = Win32ShellFolder2.createShellFolder(parent, curPIDL);
                 pIDL = Win32ShellFolder2.getNextPIDLEntry(pIDL);
             } else {

--- a/test/jdk/javax/swing/JFileChooser/4847375/bug4847375.java
+++ b/test/jdk/javax/swing/JFileChooser/4847375/bug4847375.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,14 @@
 
 /*
  * @test
- * @bug 4847375 8171363
+ * @bug 4847375 8171363 8227257
  * @requires (os.family == "windows")
  * @summary JFileChooser Create New Folder button is disabled incorrectly
  * @author Pavel Porvatov
  * @modules java.desktop/sun.awt
  *          java.desktop/sun.awt.shell:+open
+ * @run main/othervm bug4847375
+ * @run main/othervm -ea -esa bug4847375
  */
 
 import sun.awt.OSInfo;

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/InaccessibleLink.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/InaccessibleLink.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.swing.filechooser.FileSystemView;
+
+/*
+ * @test
+ * @bug 8227257
+ * @requires (os.family == "windows")
+ * @summary existing but inaccessible target for a link should be ignored
+ * @run main/othervm InaccessibleLink
+ * @run main/othervm -ea -esa InaccessibleLink
+ */
+public final class InaccessibleLink {
+
+    /**
+     * The link to the windows-update settings.
+     */
+    private static final byte[] bytes = {
+            76, 0, 0, 0, 1, 20, 2, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 70,
+            -127, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 20, 0, 31, 104, -128, 83,
+            28, -121, -96, 66, 105, 16, -94, -22, 8, 0, 43, 48, 48, -99, 62, 0,
+            97, -128, 0, 0, 0, 0, 109, 0, 115, 0, 45, 0, 115, 0, 101, 0, 116, 0,
+            116, 0, 105, 0, 110, 0, 103, 0, 115, 0, 58, 0, 119, 0, 105, 0, 110,
+            0, 100, 0, 111, 0, 119, 0, 115, 0, 117, 0, 112, 0, 100, 0, 97, 0,
+            116, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    public static void main(String[] args) throws IOException {
+        File file = new File("inaccessible.lnk");
+        try {
+            FileOutputStream fos = new FileOutputStream(file);
+            fos.write(bytes);
+            fos.close();
+
+            FileSystemView fsv = FileSystemView.getFileSystemView();
+            if (!fsv.isLink(file)) {
+                throw new RuntimeException("not a link");
+            }
+            File linkLocation = fsv.getLinkLocation(file);
+            if (linkLocation != null) {
+                throw new RuntimeException(
+                        "location is not null: " + linkLocation);
+            }
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [78b1686c](https://github.com/openjdk/jdk/commit/78b1686c150aeaa29c5d969b70c9c42c872246a2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 12 Jan 2023 and was reviewed by Alexey Ivanov and Tejesh R.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227257](https://bugs.openjdk.org/browse/JDK-8227257): javax/swing/JFileChooser/4847375/bug4847375.java fails with AssertionError


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/22.diff">https://git.openjdk.org/jdk20u/pull/22.diff</a>

</details>
