### PR TITLE
8301338: Identical branch conditions in CompileBroker::print_heapinfo

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2782,13 +2782,13 @@ void CompileBroker::print_heapinfo(outputStream* out, const char* function, size
     ts.update(); // record starting point
     MutexLocker mu11(function_lock_1, Mutex::_safepoint_check_flag);
     MutexLocker mu22(function_lock_2, Mutex::_no_safepoint_check_flag);
-    if ((function_lock_1 != NULL) || (function_lock_1 != NULL)) {
+    if ((function_lock_1 != nullptr) || (function_lock_2 != nullptr)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock wait took %10.3f seconds _________\n", ts.seconds());
     }
 
     ts.update(); // record starting point
     CodeCache::aggregate(out, granularity);
-    if ((function_lock_1 != NULL) || (function_lock_1 != NULL)) {
+    if ((function_lock_1 != nullptr) || (function_lock_2 != nullptr)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock hold took %10.3f seconds _________\n", ts.seconds());
     }
   }


### PR DESCRIPTION
Backport of [JDK-8301338](https://bugs.openjdk.java.net/browse/JDK-8301338). Did not apply cleanly due to `NULL` vs. `nullptr`. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301338](https://bugs.openjdk.org/browse/JDK-8301338): Identical branch conditions in CompileBroker::print_heapinfo ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/36.diff">https://git.openjdk.org/jdk20u/pull/36.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/36#issuecomment-1488415340)