### PR TITLE
Backport 760c0128a4ef787c8c8addb26894c072ba8b2eb1

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -813,10 +813,9 @@ static bool is_excluded_for_compiler(AbstractCompiler* comp, methodHandle& mh) {
     return true;
   }
   DirectiveSet* directive = DirectivesStack::getMatchingDirective(mh, comp);
-  if (directive->ExcludeOption) {
-    return true;
-  }
-  return false;
+  bool exclude = directive->ExcludeOption;
+  DirectivesStack::release(directive);
+  return exclude;
 }
 
 static bool can_be_compiled_at_level(methodHandle& mh, jboolean is_osr, int level) {


### PR DESCRIPTION
Backport of [JDK-8304683](https://bugs.openjdk.java.net/browse/JDK-8304683). Applies cleanly. Approval is pending.

Thanks,
Tobias