### PR TITLE
8296412: Special case infinite loops with unmerged backedges in IdealLoopTree::check_safepts

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3632,6 +3632,17 @@ void IdealLoopTree::check_safepts(VectorSet &visited, Node_List &stack) {
             // Skip to head of inner loop
             assert(_phase->is_dominator(_head, nlpt->_head), "inner head dominated by outer head");
             n = nlpt->_head;
+            if (_head == n) {
+              // this and nlpt (inner loop) have the same loop head. This should not happen because
+              // during beautify_loops we call merge_many_backedges. However, infinite loops may not
+              // have been attached to the loop-tree during build_loop_tree before beautify_loops,
+              // but then attached in the build_loop_tree afterwards, and so still have unmerged
+              // backedges. Check if we are indeed in an infinite subgraph, and terminate the scan,
+              // since we have reached the loop head of this.
+              assert(_head->as_Region()->is_in_infinite_subgraph(),
+                     "only expect unmerged backedges in infinite loops");
+              break;
+            }
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedges.jasm
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedges.jasm
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class TestInfiniteLoopWithUnmergedBackedges
+{
+    public Method "<init>":"()V"
+    stack 2 locals 1
+    {
+        aload_0;
+        invokespecial  Method java/lang/Object."<init>":"()V";
+        return;
+    }
+    static Method test_001:"(IIIII)V"
+    stack 5 locals 10
+    {
+        iload_0;
+        ifgt LOOP;
+        // below is dominated by the one above
+        iload_0;
+        ifle BACK;
+        goto HEAD;
+    HEAD:
+        iload_3;
+        ifeq BACK;
+    BACK:
+        goto HEAD;
+    LOOP:
+        iload_1;
+        iflt LOOP;
+        iload_2;
+        iflt LOOP;
+        return;
+    }
+    static Method test_002:"(IIIII)V"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt LOOP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+    LOOP:
+        iload_1;
+        iflt LOOP;
+        iload_2;
+        iflt LOOP;
+        return;
+    }
+    static Method test_003:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        // Two paths lead to HEAD, so we have an inner and outer loop
+        // But no SafePoint is placed here, because we go forward in bci
+    HEAD:
+        // SafePoint is placed here, because we go from here back in bci
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+        // loop with two backedges, which calls
+        // merge_many_backedges and then recomputes
+        // build_loop_tree
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+    static Method test_004:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        iload 9;
+        ldc 10001;
+        if_icmpeq HEAD; // a second one
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+    static Method test_005:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        iload 9;
+        ldc 10001;
+        if_icmpeq HEAD; // a second one
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296412
+ * @compile TestInfiniteLoopWithUnmergedBackedges.jasm
+ * @summary Infinite loops may not have the backedges merged, before we call IdealLoopTree::check_safepts
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-LoopUnswitching
+ *      -XX:CompileCommand=compileonly,TestInfiniteLoopWithUnmergedBackedges::test*
+ *      TestInfiniteLoopWithUnmergedBackedgesMain
+ */
+
+public class TestInfiniteLoopWithUnmergedBackedgesMain {
+    public static void main (String[] args) {
+        TestInfiniteLoopWithUnmergedBackedges.test_001(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_002(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_003(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_004(1, 0, 0, 0, 0);
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8296412](https://bugs.openjdk.java.net/browse/JDK-8296412). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296412](https://bugs.openjdk.org/browse/JDK-8296412): Special case infinite loops with unmerged backedges in IdealLoopTree::check_safepts


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/49.diff">https://git.openjdk.org/jdk20u/pull/49.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/49#issuecomment-1495990366)