### PR TITLE
8306543: GHA: MSVC installation is failing

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
-            modify --quiet --installPath 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise' \
+            modify --quiet --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
 
       - name: 'Configure'


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8306543](https://bugs.openjdk.org/browse/JDK-8306543), commit [5a00617b](https://github.com/openjdk/jdk/commit/5a00617b1be998327825c3abe82ddc213336758d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 21 Apr 2023 and was reviewed by Aleksey Shipilev and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306543](https://bugs.openjdk.org/browse/JDK-8306543): GHA: MSVC installation is failing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/58.diff">https://git.openjdk.org/jdk20u/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/58#issuecomment-1517761615)