### PR TITLE
8300575: JVMTI support when using alternative virtual thread implementation

### DIFF
--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -89,8 +89,9 @@
   do_klass(Thread_FieldHolder_klass,                    java_lang_Thread_FieldHolder                          ) \
   do_klass(Thread_Constants_klass,                      java_lang_Thread_Constants                            ) \
   do_klass(ThreadGroup_klass,                           java_lang_ThreadGroup                                 ) \
-  do_klass(BasicVirtualThread_klass,                    java_lang_BaseVirtualThread                           ) \
+  do_klass(BaseVirtualThread_klass,                     java_lang_BaseVirtualThread                           ) \
   do_klass(VirtualThread_klass,                         java_lang_VirtualThread                               ) \
+  do_klass(BoundVirtualThread_klass,                    java_lang_BoundVirtualThread                          ) \
   do_klass(Properties_klass,                            java_util_Properties                                  ) \
   do_klass(Module_klass,                                java_lang_Module                                      ) \
   do_klass(reflect_AccessibleObject_klass,              java_lang_reflect_AccessibleObject                    ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -67,6 +67,7 @@
   template(java_lang_ThreadGroup,                     "java/lang/ThreadGroup")                    \
   template(java_lang_BaseVirtualThread,               "java/lang/BaseVirtualThread")              \
   template(java_lang_VirtualThread,                   "java/lang/VirtualThread")                  \
+  template(java_lang_BoundVirtualThread,              "java/lang/ThreadBuilders$BoundVirtualThread") \
   template(java_lang_Cloneable,                       "java/lang/Cloneable")                      \
   template(java_lang_Throwable,                       "java/lang/Throwable")                      \
   template(java_lang_ClassLoader,                     "java/lang/ClassLoader")                    \

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3133,7 +3133,7 @@ JNI_END
 
 JNI_ENTRY(jboolean, jni_IsVirtualThread(JNIEnv* env, jobject obj))
   oop thread_obj = JNIHandles::resolve_external_guard(obj);
-  if (thread_obj != NULL && thread_obj->is_a(vmClasses::BasicVirtualThread_klass())) {
+  if (thread_obj != NULL && thread_obj->is_a(vmClasses::BaseVirtualThread_klass())) {
     return JNI_TRUE;
   } else {
     return JNI_FALSE;
@@ -3983,13 +3983,6 @@ jint JNICALL jni_GetEnv(JavaVM *vm, void **penv, jint version) {
   if (vm_created == 0) {
     *penv = NULL;
     ret = JNI_EDETACHED;
-    return ret;
-  }
-
-  // No JVM TI with --enable-preview and no continuations support.
-  if (!VMContinuations && Arguments::enable_preview() && JvmtiExport::is_jvmti_version(version)) {
-    *penv = NULL;
-    ret = JNI_EVERSION;
     return ret;
   }
 

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1008,9 +1008,6 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
   if (!JvmtiExport::can_support_virtual_threads()) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
-  if (!Continuations::enabled()) {
-    return JVMTI_ERROR_NONE; // Nothing to do when there are no virtual threads;
-  }
   JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle self_tobj = Handle(current, NULL);
@@ -1026,11 +1023,11 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
       return err;
     }
 
-    // Collect threads from except_list for which resumed status must be restored.
+    // Collect threads from except_list for which resumed status must be restored (only for VirtualThread case)
     for (int idx = 0; idx < except_count; idx++) {
       jthread thread = except_list[idx];
       oop thread_oop = JNIHandles::resolve_external_guard(thread);
-      if (!JvmtiVTSuspender::is_vthread_suspended(thread_oop)) {
+      if (java_lang_VirtualThread::is_instance(thread_oop) && !JvmtiVTSuspender::is_vthread_suspended(thread_oop)) {
           // is not suspended, so its resumed status must be restored
           elist->append(except_list[idx]);
       }
@@ -1042,9 +1039,10 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
           !java_thread->is_jvmti_agent_thread() &&
           !java_thread->is_hidden_from_external_view() &&
           vt_oop != NULL &&
-          java_lang_VirtualThread::is_instance(vt_oop) &&
-          JvmtiEnvBase::is_vthread_alive(vt_oop) &&
-          !JvmtiVTSuspender::is_vthread_suspended(vt_oop) &&
+          ((java_lang_VirtualThread::is_instance(vt_oop) &&
+            JvmtiEnvBase::is_vthread_alive(vt_oop) &&
+            !JvmtiVTSuspender::is_vthread_suspended(vt_oop)) ||
+            (vt_oop->is_a(vmClasses::BoundVirtualThread_klass()) && !java_thread->is_suspended())) &&
           !is_in_thread_list(except_count, except_list, vt_oop)
          ) {
         if (java_thread == current) {
@@ -1128,9 +1126,6 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
   if (!JvmtiExport::can_support_virtual_threads()) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
-  if (!Continuations::enabled()) {
-    return JVMTI_ERROR_NONE; // Nothing to do when there are no virtual threads;
-  }
   jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);
   if (err != JVMTI_ERROR_NONE) {
     return err;
@@ -1139,11 +1134,11 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
   JvmtiVTMSTransitionDisabler disabler(true);
   GrowableArray<jthread>* elist = new GrowableArray<jthread>(except_count);
 
-  // Collect threads from except_list for which suspended status must be restored.
+  // Collect threads from except_list for which suspended status must be restored (only for VirtualThread case)
   for (int idx = 0; idx < except_count; idx++) {
     jthread thread = except_list[idx];
     oop thread_oop = JNIHandles::resolve_external_guard(thread);
-    if (JvmtiVTSuspender::is_vthread_suspended(thread_oop)) {
+    if (java_lang_VirtualThread::is_instance(thread_oop) && JvmtiVTSuspender::is_vthread_suspended(thread_oop)) {
       // is suspended, so its suspended status must be restored
       elist->append(except_list[idx]);
     }
@@ -1155,9 +1150,10 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
         !java_thread->is_jvmti_agent_thread() &&
         !java_thread->is_hidden_from_external_view() &&
         vt_oop != NULL &&
-        java_lang_VirtualThread::is_instance(vt_oop) &&
-        JvmtiEnvBase::is_vthread_alive(vt_oop) &&
-        JvmtiVTSuspender::is_vthread_suspended(vt_oop) &&
+        ((java_lang_VirtualThread::is_instance(vt_oop) &&
+          JvmtiEnvBase::is_vthread_alive(vt_oop) &&
+          JvmtiVTSuspender::is_vthread_suspended(vt_oop)) ||
+          (vt_oop->is_a(vmClasses::BoundVirtualThread_klass()) && java_thread->is_suspended())) &&
         !is_in_thread_list(except_count, except_list, vt_oop)
     ) {
       resume_thread(vt_oop, java_thread, /* single_resume */ false);
@@ -1190,7 +1186,7 @@ JvmtiEnv::StopThread(jthread thread, jobject exception) {
 
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
 
-  if (thread_oop != NULL && java_lang_VirtualThread::is_instance(thread_oop)) {
+  if (thread_oop != NULL && thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).
     return JVMTI_ERROR_UNSUPPORTED_OPERATION;
   }
@@ -1560,13 +1556,13 @@ JvmtiEnv::RunAgentThread(jthread thread, jvmtiStartFunction proc, const void* ar
     // We have a valid thread_oop.
   }
 
+  if (thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
+    // No support for virtual threads.
+    return JVMTI_ERROR_UNSUPPORTED_OPERATION;
+  }
   if (java_thread != NULL) {
     // 'thread' refers to an existing JavaThread.
     return JVMTI_ERROR_INVALID_THREAD;
-  }
-  if (java_lang_VirtualThread::is_instance(thread_oop)) {
-    // No support for virtual threads.
-    return JVMTI_ERROR_UNSUPPORTED_OPERATION;
   }
 
   if (priority < JVMTI_THREAD_MIN_PRIORITY || priority > JVMTI_THREAD_MAX_PRIORITY) {
@@ -1884,7 +1880,7 @@ JvmtiEnv::PopFrame(jthread thread) {
   oop thread_obj = NULL;
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
 
-  if (thread_obj != NULL && java_lang_VirtualThread::is_instance(thread_obj)) {
+  if (thread_obj != NULL && thread_obj->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).
     return JVMTI_ERROR_OPAQUE_FRAME;
   }
@@ -3896,7 +3892,7 @@ JvmtiEnv::GetCurrentThreadCpuTime(jlong* nanos_ptr) {
   // Surprisingly the GetCurrentThreadCpuTime is used by non-JavaThread's.
   if (thread->is_Java_thread()) {
     if (JavaThread::cast(thread)->is_vthread_mounted()) {
-      // No support for virtual threads (yet).
+      // No support for a VirtualThread (yet).
       return JVMTI_ERROR_UNSUPPORTED_OPERATION;
     }
   }
@@ -3923,7 +3919,7 @@ JvmtiEnv::GetThreadCpuTime(jthread thread, jlong* nanos_ptr) {
 
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
 
-  if (thread_oop != NULL && java_lang_VirtualThread::is_instance(thread_oop)) {
+  if (thread_oop != NULL && thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).
     return JVMTI_ERROR_UNSUPPORTED_OPERATION;
   }

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1509,7 +1509,7 @@ JvmtiEnvBase::check_thread_list(jint count, const jthread* list) {
   for (int i = 0; i < count; i++) {
     jthread thread = list[i];
     oop thread_oop = JNIHandles::resolve_external_guard(thread);
-    if (thread_oop == NULL || !thread_oop->is_a(vmClasses::VirtualThread_klass())) {
+    if (thread_oop == NULL || !thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
       return JVMTI_ERROR_INVALID_THREAD;
     }
   }
@@ -1583,7 +1583,9 @@ JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool singl
   // suspension of mounted virtual thread. So, we just mark it as suspended
   // and it will be actually suspended at virtual thread unmount transition.
   if (!is_passive_cthread) {
-    assert(single_suspend || is_virtual, "SuspendAllVirtualThreads should never suspend non-virtual threads");
+    assert(thread_h() != nullptr, "sanity check");
+    assert(single_suspend || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
+           "SuspendAllVirtualThreads should never suspend non-virtual threads");
     // Case of mounted virtual or attached carrier thread.
     if (!JvmtiSuspendControl::suspend(java_thread)) {
       // Thread is already suspended or in process of exiting.
@@ -1643,7 +1645,9 @@ JvmtiEnvBase::resume_thread(oop thread_oop, JavaThread* java_thread, bool single
   assert(!java_thread->is_in_VTMS_transition(), "sanity check");
 
   if (!is_passive_cthread) {
-    assert(single_resume || is_virtual, "ResumeAllVirtualThreads should never resume non-virtual threads");
+    assert(thread_h() != nullptr, "sanity check");
+    assert(single_resume || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
+           "ResumeAllVirtualThreads should never resume non-virtual threads");
     if (java_thread->is_suspended()) {
       if (!JvmtiSuspendControl::resume(java_thread)) {
         return JVMTI_ERROR_THREAD_NOT_SUSPENDED;
@@ -1832,7 +1836,8 @@ VM_GetAllStackTraces::doit() {
     if (thread_oop != NULL &&
         !jt->is_exiting() &&
         java_lang_Thread::is_alive(thread_oop) &&
-        !jt->is_hidden_from_external_view()) {
+        !jt->is_hidden_from_external_view() &&
+        !thread_oop->is_a(vmClasses::BoundVirtualThread_klass())) {
       ++_final_thread_count;
       // Handle block of the calling thread is used to create local refs.
       _collector.fill_frames((jthread)JNIHandles::make_local(_calling_thread, thread_oop),
@@ -1919,7 +1924,7 @@ JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
   oop thread_obj = NULL;
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
 
-  if (thread_obj != NULL && java_lang_VirtualThread::is_instance(thread_obj)) {
+  if (thread_obj != NULL && thread_obj->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).
     return JVMTI_ERROR_OPAQUE_FRAME;
   }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1468,6 +1468,14 @@ void JvmtiExport::post_thread_start(JavaThread *thread) {
   // do JVMTI thread initialization (if needed)
   JvmtiEventController::thread_started(thread);
 
+  if (JvmtiExport::can_support_virtual_threads() && thread->threadObj()->is_a(vmClasses::BoundVirtualThread_klass())) {
+    // Check for VirtualThreadStart event instead.
+    HandleMark hm(thread);
+    Handle vthread(thread, thread->threadObj());
+    JvmtiExport::post_vthread_start((jthread)vthread.raw_value());
+    return;
+  }
+
   // Do not post thread start event for hidden java thread.
   if (JvmtiEventController::is_enabled(JVMTI_EVENT_THREAD_START) &&
       !thread->is_hidden_from_external_view()) {
@@ -1501,6 +1509,14 @@ void JvmtiExport::post_thread_end(JavaThread *thread) {
 
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {
+    return;
+  }
+
+  if (JvmtiExport::can_support_virtual_threads() && thread->threadObj()->is_a(vmClasses::BoundVirtualThread_klass())) {
+    // Check for VirtualThreadEnd event instead.
+    HandleMark hm(thread);
+    Handle vthread(thread, thread->threadObj());
+    JvmtiExport::post_vthread_end((jthread)vthread.raw_value());
     return;
   }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -156,7 +156,7 @@ void JavaThread::set_threadOopHandles(oop p) {
   assert(_thread_oop_storage != NULL, "not yet initialized");
   _threadObj   = OopHandle(_thread_oop_storage, p);
   _vthread     = OopHandle(_thread_oop_storage, p);
-  _jvmti_vthread = OopHandle(_thread_oop_storage, NULL);
+  _jvmti_vthread = OopHandle(_thread_oop_storage, p->is_a(vmClasses::BoundVirtualThread_klass()) ? p : NULL);
   _scopedValueCache = OopHandle(_thread_oop_storage, NULL);
 }
 

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2171,7 +2171,7 @@ JVM_ENTRY(jlong, jmm_GetThreadCpuTimeWithKind(JNIEnv *env, jlong thread_id, jboo
     java_thread = tlh.list()->find_JavaThread_from_java_tid(thread_id);
     if (java_thread != NULL) {
       oop thread_obj = java_thread->threadObj();
-      if (thread_obj != NULL && !thread_obj->is_a(vmClasses::BasicVirtualThread_klass())) {
+      if (thread_obj != NULL && !thread_obj->is_a(vmClasses::BaseVirtualThread_klass())) {
         return os::thread_cpu_time((Thread*) java_thread, user_sys_cpu_time != 0);
       }
     }

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -372,7 +372,7 @@ void ThreadService::reset_contention_time_stat(JavaThread* thread) {
 
 bool ThreadService::is_virtual_or_carrier_thread(JavaThread* jt) {
   oop threadObj = jt->threadObj();
-  if (threadObj != NULL && threadObj->is_a(vmClasses::BasicVirtualThread_klass())) {
+  if (threadObj != NULL && threadObj->is_a(vmClasses::BaseVirtualThread_klass())) {
     // a virtual thread backed by JavaThread
     return true;
   }
@@ -1090,7 +1090,8 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
 
 ThreadsListEnumerator::ThreadsListEnumerator(Thread* cur_thread,
                                              bool include_jvmti_agent_threads,
-                                             bool include_jni_attaching_threads) {
+                                             bool include_jni_attaching_threads,
+                                             bool include_bound_virtual_threads) {
   assert(cur_thread == Thread::current(), "Check current thread");
 
   int init_size = ThreadService::get_live_thread_count();
@@ -1115,6 +1116,11 @@ ThreadsListEnumerator::ThreadsListEnumerator(Thread* cur_thread,
 
     // skip jni threads in the process of attaching
     if (!include_jni_attaching_threads && jt->is_attaching_via_jni()) {
+      continue;
+    }
+
+    // skip instances of BoundVirtualThread
+    if (!include_bound_virtual_threads && jt->threadObj()->is_a(vmClasses::BoundVirtualThread_klass())) {
       continue;
     }
 

--- a/src/hotspot/share/services/threadService.hpp
+++ b/src/hotspot/share/services/threadService.hpp
@@ -411,7 +411,8 @@ private:
 public:
   ThreadsListEnumerator(Thread* cur_thread,
                         bool include_jvmti_agent_threads = false,
-                        bool include_jni_attaching_threads = true);
+                        bool include_jni_attaching_threads = true,
+                        bool include_bound_virtual_threads = false);
   int            num_threads()            { return _threads_array->length(); }
   instanceHandle get_threadObj(int index) { return _threads_array->at(index); }
 };

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2585,10 +2585,8 @@ public class Thread implements Runnable {
         StackTraceElement[][] traces = dumpThreads(threads);
         Map<Thread, StackTraceElement[]> m = HashMap.newHashMap(threads.length);
         for (int i = 0; i < threads.length; i++) {
-            Thread thread = threads[i];
             StackTraceElement[] stackTrace = traces[i];
-            // BoundVirtualThread objects may be in list returned by the VM
-            if (!thread.isVirtual() && stackTrace != null) {
+            if (stackTrace != null) {
                 m.put(threads[i], stackTrace);
             }
             // else terminated so we don't put it in the map
@@ -2658,11 +2656,7 @@ public class Thread implements Runnable {
      * Return an array of all live threads.
      */
     static Thread[] getAllThreads() {
-        Thread[] threads = getThreads();
-        return Stream.of(threads)
-                // BoundVirtualThread objects may be in list returned by the VM
-                .filter(Predicate.not(Thread::isVirtual))
-                .toArray(Thread[]::new);
+        return getThreads();
     }
 
     private static native StackTraceElement[][] dumpThreads(Thread[] threads);

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -27,7 +27,6 @@
  * @summary Run /serviceability/jvmti/RedefineClasses/RedefineRunningMethods in AppCDS mode to
  *          make sure class redefinition works with CDS.
  * @requires vm.cds
- * @requires vm.continuations
  * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/serviceability/jvmti/RedefineClasses /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver RedefineClassHelper

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalUnsuspended.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalUnsuspended.java
@@ -24,7 +24,6 @@
 /**
  * @test
  * @summary Verifies JVMTI GetLocalXXX/SetLocalXXX return errors for unsuspended vthreads
- * @requires vm.continuations
  * @enablePreview
  * @library /test/lib
  * @run main/othervm/native -agentlib:GetSetLocalUnsuspended GetSetLocalUnsuspended

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
@@ -27,7 +27,6 @@
  * @bug 8185164
  * @summary Checks that a contended monitor does not show up in the list of owned monitors
  * @requires vm.jvmti
- * @requires vm.continuations
  * @compile --enable-preview -source ${jdk.version} GetOwnedMonitorInfoTest.java
  * @run main/othervm/native --enable-preview -agentlib:GetOwnedMonitorInfoTest GetOwnedMonitorInfoTest
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoTest.java
@@ -27,7 +27,6 @@
  * @bug 8153629
  * @summary Need to cover JVMTI's GetOwnedMonitorStackDepthInfo function
  * @requires vm.jvmti
- * @requires vm.continuations
  * @compile --enable-preview -source ${jdk.version} GetOwnedMonitorStackDepthInfoTest.java
  * @run main/othervm/native --enable-preview -agentlib:GetOwnedMonitorStackDepthInfoTest GetOwnedMonitorStackDepthInfoTest
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ThreadFactory;
  * @summary Verifies that when the VM event is sent, sampled events are also collected.
  * @requires vm.jvmti
  * @requires !vm.graal.enabled
- * @requires vm.continuations
  * @build Frame HeapMonitor
  * @compile --enable-preview -source ${jdk.version} HeapMonitorVMEventsTest.java
  * @run main/othervm/native --enable-preview

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethods.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethods.java
@@ -26,7 +26,6 @@
  * @bug 8055008 8197901 8010319
  * @summary Redefine EMCP and non-EMCP methods that are running in an infinite loop
  * @requires vm.jvmti
- * @requires vm.continuations
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
@@ -26,7 +26,6 @@
  * @bug 8087315 8010319
  * @summary Get old method's stack trace elements after GC
  * @requires vm.jvmti
- * @requires vm.continuations
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/breakpoint01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Breakpoint/breakpoint01/breakpoint01.java
@@ -38,7 +38,6 @@ import java.io.*;
  *     SetBreakpoint().
  * COMMENTS
  *
- * @requires vm.continuations
  * @library /test/lib
  *
  * @comment make sure breakpoint01 is compiled with full debug info

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ClassLoad/classload01/classload01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ClassLoad/classload01/classload01.java
@@ -42,7 +42,6 @@ import java.io.*;
  * COMMENTS
  *     Fixed the 5031200 bug.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} classload01.java
  * @run main/othervm/native --enable-preview -agentlib:classload01 classload01

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ClassPrepare/classprep01/classprep01.java
@@ -37,7 +37,6 @@
  *     Fixed according to the bug 4651181.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} classprep01.java
  * @run main/othervm/native --enable-preview -agentlib:classprep01 classprep01

--- a/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/Exception/exception01/exception01.java
@@ -37,7 +37,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile exception01a.jasm
  * @compile --enable-preview -source ${jdk.version} exception01.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/ExceptionCatch/excatch01/excatch01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/ExceptionCatch/excatch01/excatch01.java
@@ -37,7 +37,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile excatch01a.jasm
  * @compile --enable-preview -source ${jdk.version} excatch01.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc01/fieldacc01.java
@@ -35,7 +35,6 @@
  *     Fixed according to 4669812 bug.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile fieldacc01a.jasm
  * @compile --enable-preview -source ${jdk.version} fieldacc01.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc02/fieldacc02.java
@@ -35,7 +35,6 @@
  *     Fixed according to 4669812 bug.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} fieldacc02.java
  * @run main/othervm/native --enable-preview -agentlib:fieldacc02 fieldacc02

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java
@@ -36,7 +36,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} fieldacc03.java
  * @run main/othervm/native --enable-preview -agentlib:fieldacc03 fieldacc03

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java
@@ -36,7 +36,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} fieldacc04.java
  * @run main/othervm/native --enable-preview -agentlib:fieldacc04 fieldacc04

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod01/fieldmod01.java
@@ -36,7 +36,6 @@
  *     Fixed according to 4669812 bug.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile fieldmod01a.jasm
  * @compile --enable-preview -source ${jdk.version} fieldmod01.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FieldModification/fieldmod02/fieldmod02.java
@@ -35,7 +35,6 @@
  *     Fixed according to 4669812 bug.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} fieldmod02.java
  * @run main/othervm/native --enable-preview -agentlib:fieldmod02 fieldmod02

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop01/framepop01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop01/framepop01.java
@@ -38,7 +38,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} framepop01a.java
  * @run main/othervm/native --enable-preview -agentlib:framepop01 framepop01

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
@@ -38,14 +38,12 @@
  *     4504077 java: dbx should not hold on to a frameid after thread suspension
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} framepop02.java
  * @run main/othervm/native --enable-preview -agentlib:framepop02 framepop02 platform
  */
 /*
  * @test
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} framepop02.java
  * @run main/othervm/native --enable-preview -agentlib:framepop02 framepop02 virtual

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry01/mentry01.java
@@ -39,7 +39,6 @@
  *     Ported from JVMDI.
  *     Fixed the 5004632 bug.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} mentry01.java
  * @run main/othervm/native --enable-preview -agentlib:mentry01 mentry01

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodEntry/mentry02/mentry02.java
@@ -37,7 +37,6 @@
  *     The test reproduced the bug on winNT 1.0fcs-E build.
  *     Ported from JVMDI test /nsk/regression/b4248826.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} mentry02.java
  * @run main/othervm/native --enable-preview -agentlib:mentry02 mentry02

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit01/mexit01.java
@@ -39,7 +39,6 @@
  *     Ported from JVMDI.
  *     Fixed the 5004632 bug.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile mexit01a.jasm
  * @compile --enable-preview -source ${jdk.version} mexit01.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MethodExit/mexit02/mexit02.java
@@ -42,7 +42,6 @@
  *     Ported from JVMDI.
  *     Fixed the 5004632 bug.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile mexit02a.jasm
  * @compile --enable-preview -source ${jdk.version} mexit02.java

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java
@@ -41,7 +41,6 @@ import jdk.test.lib.jvmti.DebugeeClass;
  *       and save JNIEnv pointer now passed as argument.
  *     1000 ms of sleep added to main thread to reduce probability of bad racing.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} mcontenter01.java
  * @run main/othervm/native --enable-preview -agentlib:mcontenter01 mcontenter01 platform

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java
@@ -40,7 +40,6 @@ import jdk.test.lib.jvmti.DebugeeClass;
  *     - change signature of agentProc function
  *       and save JNIEnv pointer now passed as argument.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} mcontentered01.java
  * @run main/othervm/native --enable-preview -agentlib:mcontentered01 mcontentered01 platform

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java
@@ -40,7 +40,6 @@ import jdk.test.lib.jvmti.DebugeeClass;
  *     - change signature of agentProc function
  *       and save JNIEnv pointer now passed as argument.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} monitorwait01.java
  * @run main/othervm/native --enable-preview -agentlib:monitorwait01 monitorwait01 platform

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java
@@ -40,7 +40,6 @@ import jdk.test.lib.jvmti.DebugeeClass;
  *     - change signature of agentProc function
  *       and save JNIEnv pointer now passed as argument.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} monitorwaited01.java
  * @run main/othervm/native --enable-preview -agentlib:monitorwaited01 monitorwaited01 platform

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java
@@ -44,7 +44,6 @@ import java.io.*;
  *     must be received.
  * COMMENTS
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} singlestep01.java
  * @run main/othervm/native --enable-preview -agentlib:singlestep01 singlestep01

--- a/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/singlestep03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/SingleStep/singlestep03/singlestep03.java
@@ -43,7 +43,6 @@ import java.io.*;
  *     the agent disables the event generation.
  * COMMENTS
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} singlestep03.java
  * @run main/othervm/native --enable-preview -agentlib:singlestep03 singlestep03 platform

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java
@@ -24,7 +24,6 @@
 /**
  * @test
  * @summary Verifies JVMTI GetStackTrace functions called without suspend.
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} GetStackTraceNotSuspendedStressTest.java
  * @run main/othervm/native --enable-preview -agentlib:GetStackTraceNotSuspendedStress GetStackTraceNotSuspendedStressTest

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java
@@ -24,7 +24,6 @@
 /**
  * @test
  * @summary Verifies JVMTI GetStackTrace functions called after vthread is suspended.
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} GetStackTraceSuspendedStressTest.java
  * @run main/othervm/native --enable-preview -agentlib:GetStackTraceSuspendedStress GetStackTraceSuspendedStressTest

--- a/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java
@@ -39,7 +39,6 @@
  *  -- update properties to run jvmti stress tests non-concurrently?
  *
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SetGetThreadLocalStorageStressTest.java
  * @run main/othervm/native --enable-preview -agentlib:SetGetThreadLocalStorageStress SetGetThreadLocalStorageStressTest

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
@@ -59,7 +59,6 @@
  *       - rearranged synchronization of tested thread
  *       - enhanced descripton
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} contmon01.java
  * @run main/othervm/native --enable-preview -agentlib:contmon01 contmon01

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon02/contmon02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon02/contmon02.java
@@ -40,7 +40,6 @@
  *       - rearranged synchronization of tested thread
  *       - enhanced descripton
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} contmon02.java
  * @run main/othervm/native --enable-preview -agentlib:contmon02 contmon02

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/GetStackTraceCurrentThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/GetStackTraceCurrentThreadTest.java
@@ -38,7 +38,6 @@
  * COMMENTS
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} GetStackTraceCurrentThreadTest.java
  * @run main/othervm/native --enable-preview -agentlib:GetStackTraceCurrentThreadTest GetStackTraceCurrentThreadTest

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java
@@ -41,7 +41,6 @@
  *     Fixed according to the 4480280 bug.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} thrinfo01.java
  * @run main/othervm/native --enable-preview -agentlib:thrinfo01 thrinfo01

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java
@@ -72,7 +72,6 @@
  *       - rearranged synchronization of tested thread
  *       - enhanced descripton
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} thrstat01.java
  * @run main/othervm/native --enable-preview -agentlib:thrstat01 thrstat01

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
@@ -37,7 +37,6 @@
  *     Converted the test to use GetThreadState instead of GetThreadStatus.
  *     Ported from JVMDI.
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} thrstat03.java
  * @run main/othervm/native --enable-preview  -agentlib:thrstat03 thrstat03 5

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat05/thrstat05.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat05/thrstat05.java
@@ -55,7 +55,6 @@
  *     For more information see bugs #5041847, #4980307 and J2SE 5.0+ JVMTI spec.
  * COMMENTS
  *
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} thrstat05.java
  * @run main/othervm/native --enable-preview -agentlib:thrstat05 thrstat05

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/BoundVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/BoundVThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,56 +21,41 @@
  * questions.
  */
 
-/*
- * @test id=default
- * @summary Verifies JVMTI InterruptThread works for virtual threads.
- * @compile --enable-preview -source ${jdk.version} InterruptThreadTest.java
- * @run main/othervm/native --enable-preview -agentlib:InterruptThreadTest InterruptThreadTest
- */
-
-/*
- * @test id=no-vmcontinuations
- * @requires vm.continuations
- * @compile --enable-preview -source ${jdk.version} InterruptThreadTest.java
- * @run main/othervm/native --enable-preview -agentlib:InterruptThreadTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations InterruptThreadTest
+/**
+ * @test
+ * @summary Verifies correct JVMTI behavior for BoundVirtualThreads.
+ * @enablePreview
+ * @run main/othervm/native -agentlib:BoundVThreadTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations BoundVThreadTest
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class InterruptThreadTest {
-    private static final String AGENT_LIB = "InterruptThreadTest";
+public class BoundVThreadTest {
+    private static final String AGENT_LIB = "BoundVThreadTest";
     final Object lock = new Object();
+    final AtomicBoolean shouldFinish = new AtomicBoolean(false);
 
-    native boolean testJvmtiFunctionsInJNICall(Thread vthread);
-
-    volatile private boolean target_is_ready = false;
-    private boolean iterrupted = false;
+    static native boolean testJvmtiFunctions(Thread vthread, ThreadGroup group);
+    static native boolean check();
 
     final Runnable pinnedTask = () -> {
         synchronized (lock) {
-            try {
-                target_is_ready = true;
-                lock.wait();
-            } catch (InterruptedException ie) {
-                 System.err.println("Virtual thread was interrupted as expected");
-                 iterrupted = true;
-            }
+            do {
+                try {
+                    lock.wait(10);
+                } catch (InterruptedException ie) {}
+            } while (!shouldFinish.get());
         }
+        testJvmtiFunctions(Thread.currentThread(), Thread.currentThread().getThreadGroup());
     };
 
     void runTest() throws Exception {
         Thread vthread = Thread.ofVirtual().name("VThread").start(pinnedTask);
-
-        // wait for target virtual thread to reach the expected waiting state
-        while (!target_is_ready) {
-           synchronized (lock) {
-              lock.wait(1);
-            }
-        }
-        testJvmtiFunctionsInJNICall(vthread);
+        testJvmtiFunctions(vthread, Thread.currentThread().getThreadGroup());
+        shouldFinish.set(true);
         vthread.join();
-        if (!iterrupted) {
-            throw new RuntimeException("Failed: Virtual thread was not interrupted!");
+        if (!check()) {
+            throw new RuntimeException("BoundVThreadTest failed!");
         }
     }
 
@@ -82,7 +67,7 @@ public class InterruptThreadTest {
             System.err.println("java.library.path: " + System.getProperty("java.library.path"));
             throw ex;
         }
-        InterruptThreadTest t = new InterruptThreadTest();
+        BoundVThreadTest t = new BoundVThreadTest();
         t.runTest();
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/libBoundVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/libBoundVThreadTest.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jvmti.h"
+#include "jvmti_common.h"
+
+extern "C" {
+
+#define MAX_FRAMES 100
+
+static jvmtiEnv *jvmti = nullptr;
+static int vthread_start_count = 0;
+static int vthread_end_count = 0;
+static bool status = JNI_TRUE;
+
+static void
+check_jvmti_error_unsupported_operation(JNIEnv* jni, const char* msg, jvmtiError err) {
+  if (err != JVMTI_ERROR_UNSUPPORTED_OPERATION) {
+    LOG("%s failed: expected JVMTI_ERROR_UNSUPPORTED_OPERATION instead of: %d\n", msg, err);
+    fatal(jni, msg);
+  }
+}
+
+static void
+check_jvmti_error_opaque_frame(JNIEnv* jni, const char* msg, jvmtiError err) {
+  if (err != JVMTI_ERROR_OPAQUE_FRAME) {
+    LOG("%s failed: expected JVMTI_ERROR_OPAQUE_FRAME instead of: %d\n", msg, err);
+    fatal(jni, msg);
+  }
+}
+
+static void JNICALL
+agent_proc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
+  fatal(jni, "agent function was not expected to be called");
+}
+
+static void
+check_suspended_state(JNIEnv* jni, jthread thread) {
+  jint state = 0;
+
+  char* tname = get_thread_name(jvmti, jni, thread);
+
+  jvmtiError err = jvmti->GetThreadState(thread, &state);
+  check_jvmti_status(jni, err, "check_suspended_state: error in JVMTI GetThreadState");
+  LOG("## Agent: %p %s: state after suspend: %s (%d)\n", thread,  tname, TranslateState(state), (int)state);
+
+  if ((state & (JVMTI_THREAD_STATE_SUSPENDED | JVMTI_THREAD_STATE_TERMINATED)) == 0) {
+    LOG("\n## Agent: FAILED: SUSPENDED flag is not set:\n");
+    status = JNI_FALSE;
+  }
+  deallocate(jvmti, jni, (void*)tname);
+}
+
+static void
+check_resumed_state(JNIEnv* jni, jthread thread) {
+  jint state = 0;
+
+  char* tname = get_thread_name(jvmti, jni, thread);
+
+  jvmtiError err = jvmti->GetThreadState(thread, &state);
+  check_jvmti_status(jni, err, "check_resumed_state: error in JVMTI GetThreadState");
+  LOG("## Agent: %p %s: state after resume: %s (%d)\n", thread,  tname, TranslateState(state), (int)state);
+
+  if ((state & (JVMTI_THREAD_STATE_SUSPENDED | JVMTI_THREAD_STATE_TERMINATED)) != 0) {
+    LOG("\n## Agent: FAILED: SUSPENDED flag is set:\n");
+    status = JNI_FALSE;
+  }
+  deallocate(jvmti, jni, (void*)tname);
+}
+
+static void
+test_unsupported_jvmti_functions(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread, jthreadGroup group) {
+  jvmtiCapabilities caps;
+  jvmtiError err;
+  jboolean is_vthread;
+  jthread* threads_ptr = nullptr;
+  jthreadGroup* groups_ptr = nullptr;
+  jvmtiStackInfo *stack_info;
+  jint thread_cnt = 0;
+  jint group_cnt = 0;
+  jlong nanos;
+
+  LOG("test_unsupported_jvmti_functions: started\n");
+
+  is_vthread = jni->IsVirtualThread(vthread);
+  if (is_vthread != JNI_TRUE) {
+    fatal(jni, "IsVirtualThread failed to return JNI_TRUE");
+  }
+
+  err = jvmti->GetCapabilities(&caps);
+  check_jvmti_status(jni, err, "GetCapabilities");
+
+  if (caps.can_support_virtual_threads != JNI_TRUE) {
+    fatal(jni, "Virtual threads are not supported");
+  }
+
+  LOG("Testing StopThread\n");
+  err = jvmti->StopThread(vthread, vthread);
+  check_jvmti_error_unsupported_operation(jni, "StopThread", err);
+
+  LOG("Testing PopFrame\n");
+  err = jvmti->PopFrame(vthread);
+  check_jvmti_error_opaque_frame(jni, "PopFrame", err);
+
+  LOG("Testing ForceEarlyReturnVoid\n");
+  err = jvmti->ForceEarlyReturnVoid(vthread);
+  check_jvmti_error_opaque_frame(jni, "ForceEarlyReturnVoid", err);
+
+  LOG("Testing GetThreadCpuTime\n");
+  err = jvmti->GetThreadCpuTime(vthread, &nanos);
+  check_jvmti_error_unsupported_operation(jni, "GetThreadCpuTime", err);
+
+  LOG("Testing RunAgentThread\n");
+  err = jvmti->RunAgentThread(vthread, agent_proc, (const void*)nullptr, JVMTI_THREAD_NORM_PRIORITY);
+  check_jvmti_error_unsupported_operation(jni, "RunAgentThread", err);
+
+  LOG("Testing GetAllThreads\n");
+  err = jvmti->GetAllThreads(&thread_cnt, &threads_ptr);
+  check_jvmti_status(jni, err, "test_unsupported_jvmti_functions: error in JVMTI GetAllThreads");
+  for (int idx = 0; idx < thread_cnt; idx++) {
+    jthread thread = threads_ptr[idx];
+    if (jni->IsVirtualThread(thread)) {
+      fatal(jni, "GetAllThreads should not include virtual threads");
+    }
+  }
+
+  LOG("Testing GetAllStackTraces\n");
+  err = jvmti->GetAllStackTraces(MAX_FRAMES, &stack_info, &thread_cnt);
+  check_jvmti_status(jni, err, "test_unsupported_jvmti_functions: error in JVMTI GetAllStackTraces");
+  for (int idx = 0; idx < thread_cnt; idx++) {
+    jthread thread = threads_ptr[idx];
+    if (jni->IsVirtualThread(thread)) {
+      fatal(jni, "GetAllStackTraces should not include virtual threads");
+    }
+  }
+
+  LOG("Testing GetThreadGroupChildren\n");
+  err = jvmti->GetThreadGroupChildren(group, &thread_cnt, &threads_ptr, &group_cnt, &groups_ptr);
+  check_jvmti_status(jni, err, "test_unsupported_jvmti_functions: error in JVMTI GetThreadGroupChildren");
+  for (int idx = 0; idx < thread_cnt; idx++) {
+    jthread thread = threads_ptr[idx];
+    if (jni->IsVirtualThread(thread)) {
+      fatal(jni, "GetThreadGroupChildren should not include virtual threads");
+    }
+  }
+
+  LOG("test_unsupported_jvmti_functions: finished\n");
+}
+
+static void
+test_supported_jvmti_functions(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread) {
+  jvmtiError err;
+
+  LOG("test_supported_jvmti_functions: started\n");
+
+  LOG("Testing SuspendThread\n");
+  err = jvmti->SuspendThread(vthread);
+  check_jvmti_status(jni, err, "test_supported_jvmti_functions: error in JVMTI SuspendThread");
+  check_suspended_state(jni, vthread);
+
+  LOG("Testing ResumeThread\n");
+  err = jvmti->ResumeThread(vthread);
+  check_jvmti_status(jni, err, "test_supported_jvmti_functions: error in JVMTI ResumeThread");
+  check_resumed_state(jni, vthread);
+
+  LOG("Testing SuspendAllVirtualThreads\n");
+  err = jvmti->SuspendAllVirtualThreads(0, nullptr);
+  check_jvmti_status(jni, err, "test_supported_jvmti_functions: error in JVMTI SuspendAllVirtualThreads");
+  check_suspended_state(jni, vthread);
+
+  LOG("Testing ResumeAllVirtualThreads\n");
+  err = jvmti->ResumeAllVirtualThreads(0, nullptr);
+  check_jvmti_status(jni, err, "test_supported_jvmti_functions: error in JVMTI ResumeAllVirtualThreads");
+  check_resumed_state(jni, vthread);
+
+  LOG("test_supported_jvmti_functions: finished\n");
+}
+
+JNIEXPORT jboolean JNICALL
+Java_BoundVThreadTest_testJvmtiFunctions(JNIEnv *jni, jclass cls, jthread vthread, jthreadGroup group) {
+  jvmtiError err = JVMTI_ERROR_NONE;
+  jthread current;
+
+  LOG("testJvmtiFunctions: started\n");
+
+  test_unsupported_jvmti_functions(jvmti, jni, vthread, group);
+
+  current = get_current_thread(jvmti, jni);
+  if (!jni->IsVirtualThread(current)) {
+    test_supported_jvmti_functions(jvmti, jni, vthread);
+  }
+
+  LOG("testJvmtiFunctions: finished\n");
+
+  return JNI_TRUE;
+}
+
+static void JNICALL
+VirtualThreadStart(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread) {
+  vthread_start_count++;
+}
+
+static void JNICALL
+VirtualThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread) {
+  vthread_end_count++;
+}
+
+extern JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  jvmtiEventCallbacks callbacks;
+  jvmtiCapabilities caps;
+  jvmtiError err;
+
+  LOG("Agent_OnLoad started\n");
+  if (jvm->GetEnv((void **)(&jvmti), JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+
+  memset(&caps, 0, sizeof (caps));
+  caps.can_signal_thread = 1;
+  caps.can_pop_frame = 1;
+  caps.can_force_early_return = 1;
+  caps.can_support_virtual_threads = 1;
+  caps.can_get_thread_cpu_time = 1;
+  caps.can_get_current_thread_cpu_time = 1;
+  caps.can_suspend = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.VirtualThreadStart = &VirtualThreadStart;
+  callbacks.VirtualThreadEnd = &VirtualThreadEnd;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_START, nullptr);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VIRTUAL_THREAD_END, nullptr);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
+    return JNI_ERR;
+  }
+
+  LOG("Agent_OnLoad finished\n");
+  return JNI_OK;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_BoundVThreadTest_check(JNIEnv *jni, jclass cls) {
+  LOG("\n");
+  LOG("check: started\n");
+
+  LOG("check: vthread_start_count: %d\n", vthread_start_count);
+  LOG("check: vthread_end_count: %d\n", vthread_end_count);
+
+  if (vthread_start_count == 0) {
+    status = JNI_FALSE;
+    LOG("FAILED: vthread_start_count == 0\n");
+  }
+  if (vthread_end_count == 0) {
+    status = JNI_FALSE;
+    LOG("FAILED: vthread_end_count == 0\n");
+  }
+
+  LOG("check: finished\n");
+  LOG("\n");
+  return status;
+}
+
+} // extern "C"

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java
@@ -21,12 +21,18 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary Verifies specific JVMTI functions work with current virtual thread passed as NULL.
- * @requires vm.continuations
  * @compile --enable-preview -source ${jdk.version} NullAsCurrentThreadTest.java
  * @run main/othervm/native --enable-preview -agentlib:NullAsCurrentThreadTest=EnableVirtualThreadSupport NullAsCurrentThreadTest
+ */
+
+/**
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @compile --enable-preview -source ${jdk.version} NullAsCurrentThreadTest.java
+ * @run main/othervm/native --enable-preview -agentlib:NullAsCurrentThreadTest=EnableVirtualThreadSupport -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations NullAsCurrentThreadTest
  */
 
 public class NullAsCurrentThreadTest {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/PinnedTaskTest/PinnedTaskTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/PinnedTaskTest/PinnedTaskTest.java
@@ -21,12 +21,18 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary Verifies JVMTI hadles pinned virtual threads correctly.
- * @requires vm.continuations
  * @compile --enable-preview -source ${jdk.version} PinnedTaskTest.java
  * @run main/othervm/native --enable-preview -agentlib:PinnedTaskTest PinnedTaskTest
+ */
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @compile --enable-preview -source ${jdk.version} PinnedTaskTest.java
+ * @run main/othervm/native --enable-preview -agentlib:PinnedTaskTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations PinnedTaskTest
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
@@ -22,12 +22,19 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary Test verifies that selfsuspend doesn' block unmount by VTMTDisabler
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SelfSuspendDisablerTest.java
  * @run main/othervm/native --enable-preview -agentlib:SelfSuspendDisablerTest SelfSuspendDisablerTest
+ */
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @library /test/lib
+ * @compile --enable-preview -source ${jdk.version} SelfSuspendDisablerTest.java
+ * @run main/othervm/native --enable-preview -agentlib:SelfSuspendDisablerTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations SelfSuspendDisablerTest
  */
 
 public class SelfSuspendDisablerTest {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -22,9 +22,21 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary Test SuspendThread/ResumeThread, SuspendThreadList/ResumeThreadList
  *          for virtual threads.
+ * @library /test/lib
+ * @compile --enable-preview -source ${jdk.version} SuspendResume1.java
+ * @run driver jdk.test.lib.FileInstaller . .
+ * @run main/othervm/native/timeout=600
+ *      --enable-preview
+ *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -agentlib:SuspendResume1
+ *      SuspendResume1
+ */
+
+ /*
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SuspendResume1.java
@@ -33,6 +45,8 @@
  *      --enable-preview
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume1
+ *      -XX:+UnlockExperimentalVMOptions
+ *      -XX:-VMContinuations
  *      SuspendResume1
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
@@ -22,8 +22,20 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary Test SuspendAllVirtualThreads/ResumeAllVirtualThreads
+ * @library /test/lib
+ * @compile --enable-preview -source ${jdk.version} SuspendResume2.java
+ * @run driver jdk.test.lib.FileInstaller . .
+ * @run main/othervm/native
+ *      --enable-preview
+ *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -agentlib:SuspendResume2
+ *      SuspendResume2
+ */
+
+/*
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SuspendResume2.java
@@ -32,6 +44,8 @@
  *      --enable-preview
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume2
+ *      -XX:+UnlockExperimentalVMOptions
+ *      -XX:-VMContinuations
  *      SuspendResume2
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
@@ -22,8 +22,20 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary Test SuspendAllVirtualThreads/ResumeAllVirtualThreads
+ * @library /test/lib
+ * @compile --enable-preview -source ${jdk.version} SuspendResumeAll.java
+ * @run driver jdk.test.lib.FileInstaller . .
+ * @run main/othervm/native
+ *      --enable-preview
+ *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -agentlib:SuspendResumeAll
+ *      SuspendResumeAll
+ */
+
+/*
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} SuspendResumeAll.java
@@ -32,6 +44,8 @@
  *      --enable-preview
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResumeAll
+ *      -XX:+UnlockExperimentalVMOptions
+ *      -XX:-VMContinuations
  *      SuspendResumeAll
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java
@@ -21,10 +21,21 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @bug 8284161 8288214
  * @summary Verifies that FRAME_POP event is delivered when called from URL.openStream().
+ * @enablePreview
+ * @modules jdk.httpserver
+ * @library /test/lib
+ * @run main/othervm/native
+ *     -agentlib:VThreadNotifyFramePopTest
+ *     -Djdk.defaultScheduler.parallelism=2 -Djdk.defaultScheduler.maxPoolSize=2
+ *     VThreadNotifyFramePopTest
+ */
+
+/*
+ * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @enablePreview
  * @modules jdk.httpserver
@@ -32,6 +43,8 @@
  * @run main/othervm/native
  *     -agentlib:VThreadNotifyFramePopTest
  *     -Djdk.defaultScheduler.parallelism=2 -Djdk.defaultScheduler.maxPoolSize=2
+ *     -XX:+UnlockExperimentalVMOptions
+ *     -XX:-VMContinuations
  *     VThreadNotifyFramePopTest
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
@@ -21,13 +21,20 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary Verifies JVMTI GetStackTrace does not truncate virtual thread stack trace with agent attach
  * @requires vm.jvmti
- * @requires vm.continuations
  * @enablePreview
  * @run main/othervm/native -Djdk.attach.allowAttachSelf=true VirtualStackTraceTest
+ */
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @enablePreview
+ * @run main/othervm/native -Djdk.attach.allowAttachSelf=true -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualStackTraceTest
  */
 
 import com.sun.tools.attach.VirtualMachine;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualThreadStartTest/VirtualThreadStartTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualThreadStartTest/VirtualThreadStartTest.java
@@ -21,16 +21,25 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary Verifies JVMTI can_support_virtual_threads works for agents loaded at startup and into running VM
  * @requires vm.jvmti
- * @requires vm.continuations
  * @enablePreview
  * @run main/othervm/native -agentlib:VirtualThreadStartTest VirtualThreadStartTest
  * @run main/othervm/native -agentlib:VirtualThreadStartTest=can_support_virtual_threads VirtualThreadStartTest
  * @run main/othervm/native -Djdk.attach.allowAttachSelf=true VirtualThreadStartTest attach
  * @run main/othervm/native -Djdk.attach.allowAttachSelf=true VirtualThreadStartTest attach can_support_virtual_threads
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @enablePreview
+ * @run main/othervm/native -agentlib:VirtualThreadStartTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadStartTest
+ * @run main/othervm/native -agentlib:VirtualThreadStartTest=can_support_virtual_threads -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadStartTest
+ * @run main/othervm/native -Djdk.attach.allowAttachSelf=true -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadStartTest attach
+ * @run main/othervm/native -Djdk.attach.allowAttachSelf=true -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations VirtualThreadStartTest attach can_support_virtual_threads
  */
 
 import com.sun.tools.attach.VirtualMachine;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/premain/AgentWithVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/premain/AgentWithVThreadTest.java
@@ -28,7 +28,6 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @summary Test verifies that virtual threads can be executed in premain()
  * @requires vm.jvmti
- * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} AgentWithVThread.java AgentWithVThreadTest.java
  * @run driver jdk.test.lib.util.JavaAgentBuilder AgentWithVThread agent.jar

--- a/test/jdk/com/sun/jdi/JdbOptions.java
+++ b/test/jdk/com/sun/jdi/JdbOptions.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8234808
  *
- * @requires vm.continuations
  * @library /test/lib
  * @run main/othervm JdbOptions
  */

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -26,7 +26,6 @@
  * @bug 8287847
  * @summary Test suspending a platform thread after it has terminated.
  * @enablePreview
- * @requires vm.continuations
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile SuspendAfterDeath.java
  * @run main/othervm SuspendAfterDeath
@@ -37,7 +36,6 @@
  * @bug 8287847
  * @summary Test suspending a virtual thread after it has terminated.
  * @enablePreview
- * @requires vm.continuations
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile SuspendAfterDeath.java
  * @run main/othervm SuspendAfterDeath Virtual

--- a/test/langtools/jdk/jshell/Test8294583.java
+++ b/test/langtools/jdk/jshell/Test8294583.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8294583
  * @summary JShell: NPE in switch with non existing record pattern
- * @requires vm.continuations
  * @build KullaTesting TestingInputStream
  * @run testng Test8294583
  */

--- a/test/langtools/jdk/jshell/Test8296012.java
+++ b/test/langtools/jdk/jshell/Test8296012.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8296012
  * @summary jshell crashes on mismatched record pattern
- * @requires vm.continuations
  * @build KullaTesting TestingInputStream
  * @run testng Test8296012
  */

--- a/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
+++ b/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8199193
  * @summary Tests for the --enable-preview option
- * @requires vm.continuations
  * @run testng ToolEnablePreviewTest
  */
 


### PR DESCRIPTION
This PR backports modifications to the jvmti code to add support for vthreads. Without this change, we see many failures in our internal testing.

These changes did not apply cleanly in several places because of changes related to JDK-8299837 (Replace NULL with nullptr in hotspot code and tests). In these places, the changes expected code containing nullptr, but found NULL. In these spots, kept the code from the backported change, but changed nullptr back to NULL for consistency with the rest of the code base.

Testing is underway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300575](https://bugs.openjdk.org/browse/JDK-8300575): JVMTI support when using alternative virtual thread implementation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/60.diff">https://git.openjdk.org/jdk20u/pull/60.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/60#issuecomment-1520540195)