### PR TITLE
8289735: UTIL_LOOKUP_PROGS fails on pathes with space

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -60,6 +60,7 @@ AC_DEFUN([BASIC_CHECK_LEFTOVER_OVERRIDDEN],
 
 ###############################################################################
 # Setup basic configuration paths, and platform-specific stuff related to PATHs.
+# Make sure to only use tools set up in BASIC_SETUP_FUNDAMENTAL_TOOLS.
 AC_DEFUN_ONCE([BASIC_SETUP_PATHS],
 [
   # Save the current directory this script was started from

--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -49,6 +49,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(WC, wc)
 
   # Required tools with some special treatment
+  UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
   UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
   UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
 
@@ -94,7 +95,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_TOOLS],
   UTIL_REQUIRE_PROGS(XARGS, xargs)
 
   # Required tools with some special treatment
-  UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
   UTIL_REQUIRE_SPECIAL(FGREP, [AC_PROG_FGREP])
 
   # Optional tools, we can do without them

--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -29,8 +29,8 @@
 RECOMMENDED_PANDOC_VERSION=2.19.2
 
 ###############################################################################
-# Setup the most fundamental tools that relies on not much else to set up,
-# but is used by much of the early bootstrap code.
+# Setup the most fundamental tools, used for setting up build platform and
+# path handling.
 AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
 [
   # Bootstrapping: These tools are needed by UTIL_LOOKUP_PROGS
@@ -42,7 +42,27 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_CHECK_NONEMPTY(FILE)
   AC_PATH_PROGS(LDD, ldd)
 
-  # First are all the fundamental required tools.
+  # Required tools
+  UTIL_REQUIRE_PROGS(ECHO, echo)
+  UTIL_REQUIRE_PROGS(TR, tr)
+  UTIL_REQUIRE_PROGS(UNAME, uname)
+  UTIL_REQUIRE_PROGS(WC, wc)
+
+  # Required tools with some special treatment
+  UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
+  UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
+
+  # Tools only needed on some platforms
+  UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)
+  UTIL_LOOKUP_PROGS(CMD, cmd.exe, $PATH:/cygdrive/c/windows/system32:/mnt/c/windows/system32:/c/windows/system32)
+])
+
+###############################################################################
+# Setup further tools that should be resolved early but after setting up
+# build platform and path handling.
+AC_DEFUN_ONCE([BASIC_SETUP_TOOLS],
+[
+  # Required tools
   UTIL_REQUIRE_PROGS(BASH, bash)
   UTIL_REQUIRE_PROGS(CAT, cat)
   UTIL_REQUIRE_PROGS(CHMOD, chmod)
@@ -50,7 +70,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(CUT, cut)
   UTIL_REQUIRE_PROGS(DATE, date)
   UTIL_REQUIRE_PROGS(DIFF, gdiff diff)
-  UTIL_REQUIRE_PROGS(ECHO, echo)
   UTIL_REQUIRE_PROGS(EXPR, expr)
   UTIL_REQUIRE_PROGS(FIND, find)
   UTIL_REQUIRE_PROGS(GUNZIP, gunzip)
@@ -72,16 +91,11 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(TAR, gtar tar)
   UTIL_REQUIRE_PROGS(TEE, tee)
   UTIL_REQUIRE_PROGS(TOUCH, touch)
-  UTIL_REQUIRE_PROGS(TR, tr)
-  UTIL_REQUIRE_PROGS(UNAME, uname)
-  UTIL_REQUIRE_PROGS(WC, wc)
   UTIL_REQUIRE_PROGS(XARGS, xargs)
 
-  # Then required tools that require some special treatment.
+  # Required tools with some special treatment
   UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
-  UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
   UTIL_REQUIRE_SPECIAL(FGREP, [AC_PROG_FGREP])
-  UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
 
   # Optional tools, we can do without them
   UTIL_LOOKUP_PROGS(DF, df)
@@ -89,10 +103,8 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_LOOKUP_PROGS(NICE, nice)
   UTIL_LOOKUP_PROGS(READLINK, greadlink readlink)
 
-  # These are only needed on some platforms
-  UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)
+  # Tools only needed on some platforms
   UTIL_LOOKUP_PROGS(LSB_RELEASE, lsb_release)
-  UTIL_LOOKUP_PROGS(CMD, cmd.exe, $PATH:/cygdrive/c/windows/system32:/mnt/c/windows/system32:/c/windows/system32)
 
   # For compare.sh only
   UTIL_LOOKUP_PROGS(CMP, cmp)

--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -86,6 +86,7 @@ PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET
 
 # Continue setting up basic stuff. Most remaining code require fundamental tools.
 BASIC_SETUP_PATHS
+BASIC_SETUP_TOOLS
 
 # Check if it's a pure open build or if custom sources are to be used.
 JDKOPT_SETUP_OPEN_OR_CUSTOM

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -640,6 +640,7 @@ AC_DEFUN([PLATFORM_SET_MODULE_TARGET_OS_VALUES],
 ])
 
 #%%% Build and target systems %%%
+# Make sure to only use tools set up in BASIC_SETUP_FUNDAMENTAL_TOOLS.
 AC_DEFUN_ONCE([PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET],
 [
   # Figure out the build and target systems. # Note that in autoconf terminology, "build" is obvious, but "target"
@@ -723,7 +724,7 @@ AC_DEFUN_ONCE([PLATFORM_SETUP_OPENJDK_TARGET_ENDIANNESS],
 [
   ###############################################################################
   #
-  # Is the target little of big endian?
+  # Is the target little or big endian?
   #
   AC_C_BIGENDIAN([ENDIAN="big"],[ENDIAN="little"],[ENDIAN="unknown"],[ENDIAN="universal_endianness"])
 


### PR DESCRIPTION
I had to resolve configure.ac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8289735](https://bugs.openjdk.org/browse/JDK-8289735): UTIL_LOOKUP_PROGS fails on pathes with space
 * [JDK-8306976](https://bugs.openjdk.org/browse/JDK-8306976): UTIL_REQUIRE_SPECIAL warning on grep


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/63.diff">https://git.openjdk.org/jdk20u/pull/63.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/63#issuecomment-1522381642)