### PR TITLE
8304295: harfbuzz build fails with GCC 7 after JDK-8301998

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -470,7 +470,8 @@ else
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers strict-aliasing \
        unused-result
-   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess
+   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [34e66ce1](https://github.com/openjdk/jdk/commit/34e66ce1ef2decc81557a362d6242313e98417fa) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Joshua Cao on 1 Apr 2023 and was reviewed by Aleksey Shipilev, Erik Joelsson, Sergey Bylokhov and Julian Waters.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304295](https://bugs.openjdk.org/browse/JDK-8304295): harfbuzz build fails with GCC 7 after JDK-8301998


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/68.diff">https://git.openjdk.org/jdk20u/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/68#issuecomment-1526063237)