### PR TITLE
Read length of SNIServerName as unsigned.

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -408,7 +408,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         } else {
             requestedServerNames = new ArrayList<>();
             while (len > 0) {
-                int l = buf.get();
+                int l = Byte.toUnsignedInt(buf.get());
                 b = new byte[l];
                 buf.get(b, 0, l);
                 requestedServerNames.add(new SNIHostName(new String(b)));


### PR DESCRIPTION
The RFC allows Server Names to have up to 255 characters. The current code fails for names with length > 127. See https://www.rfc-editor.org/rfc/rfc6066#section-3