### PR TITLE
8307346: Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -311,7 +311,10 @@ void G1FullCollector::phase1_mark_live_objects() {
     _heap->complete_cleaning(purged_class);
   }
 
-  scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) debug("Report Object Count", scope()->timer());
+    scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  }
 #if TASKQUEUE_STATS
   oop_queue_set()->print_and_reset_taskqueue_stats("Oop Queue");
   array_queue_set()->print_and_reset_taskqueue_stats("ObjArrayOop Queue");

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2070,7 +2070,10 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  {
+    GCTraceTime(Debug, gc, phases) tm("Report Object Count", &_gc_timer);
+    _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  }
 #if TASKQUEUE_STATS
   ParCompactionManager::oop_task_queues()->print_and_reset_taskqueue_stats("Oop Queue");
   ParCompactionManager::_objarray_task_queues->print_and_reset_taskqueue_stats("ObjArrayOop Queue");

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -230,7 +230,10 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  gc_tracer()->report_object_count_after_gc(&is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Report Object Count", gc_timer());
+    gc_tracer()->report_object_count_after_gc(&is_alive);
+  }
 }
 
 


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [3f1927a7](https://github.com/openjdk/jdk/commit/3f1927a7f3a2914402a25335c47a5a8bdd5511a6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Oli Gillespie on 4 May 2023 and was reviewed by Thomas Schatzl, Aleksey Shipilev and Albert Mingkun Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307346](https://bugs.openjdk.org/browse/JDK-8307346): Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/79.diff">https://git.openjdk.org/jdk20u/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/79#issuecomment-1549307047)