### PR TITLE
8304350: Font.getStringBounds calculates wrong width for TextAttribute.TRACKING other than 0.0

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -2629,8 +2629,10 @@ public class Font implements java.io.Serializable
         // quick check for simple text, assume GV ok to use if simple
 
         boolean simple = values == null ||
-            (values.getKerning() == 0 && values.getLigatures() == 0 &&
-              values.getBaselineTransform() == null);
+            (values.getKerning() == 0
+             && values.getLigatures() == 0
+             && values.getTracking() == 0
+             && values.getBaselineTransform() == null);
         if (simple) {
             simple = ! FontUtilities.isComplexText(chars, beginIndex, limit);
         }


### PR DESCRIPTION
This is a clean backport of 8304350 for jdk20u. Using the reproducers in the original bug report, I have verified that a) jdk20u is affected, and b) this patch resolves the bug in 20u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304350](https://bugs.openjdk.org/browse/JDK-8304350): Font.getStringBounds calculates wrong width for TextAttribute.TRACKING other than 0.0


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/81.diff">https://git.openjdk.org/jdk20u/pull/81.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/81#issuecomment-1553185658)