### PR TITLE
8305668: PPC: Non-Top Interpreted frames should be independent of ABI_ELFv2

### DIFF
--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
 // Note: This returns the conservative size assuming maximum alignment.
 int AbstractInterpreter::size_top_interpreter_activation(Method* method) {
   const int max_alignment_size = 2;
-  const int abi_scratch = frame::abi_reg_args_size;
+  const int abi_scratch = frame::top_ijava_frame_abi_size;
   return method->max_locals() + method->max_stack() +
          frame::interpreter_frame_monitor_size() + max_alignment_size + abi_scratch;
 }
@@ -76,8 +76,8 @@ int AbstractInterpreter::size_activation(int max_stack,
   // in TemplateInterpreterGenerator::generate_fixed_frame.
   assert(Interpreter::stackElementWords == 1, "sanity");
   const int max_alignment_space = StackAlignmentInBytes / Interpreter::stackElementSize;
-  const int abi_scratch = is_top_frame ? (frame::abi_reg_args_size / Interpreter::stackElementSize) :
-                                         (frame::abi_minframe_size / Interpreter::stackElementSize);
+  const int abi_scratch = is_top_frame ? (frame::top_ijava_frame_abi_size / Interpreter::stackElementSize) :
+                                         (frame::parent_ijava_frame_abi_size / Interpreter::stackElementSize);
   const int size =
     max_stack                                                +
     (callee_locals - callee_params)                          +
@@ -122,20 +122,20 @@ void AbstractInterpreter::layout_activation(Method* method,
                                             bool is_top_frame,
                                             bool is_bottom_frame) {
 
-  const int abi_scratch = is_top_frame ? (frame::abi_reg_args_size / Interpreter::stackElementSize) :
-                                         (frame::abi_minframe_size / Interpreter::stackElementSize);
+  const int abi_scratch = is_top_frame ? (frame::top_ijava_frame_abi_size / Interpreter::stackElementSize) :
+                                         (frame::parent_ijava_frame_abi_size / Interpreter::stackElementSize);
 
   intptr_t* locals_base  = (caller->is_interpreted_frame()) ?
     caller->interpreter_frame_esp() + caller_actual_parameters :
-    caller->sp() + method->max_locals() - 1 + (frame::abi_minframe_size / Interpreter::stackElementSize);
+    caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
 
   intptr_t* monitor_base = caller->sp() - frame::ijava_state_size / Interpreter::stackElementSize;
   intptr_t* monitor      = monitor_base - (moncount * frame::interpreter_frame_monitor_size());
   intptr_t* esp_base     = monitor - 1;
   intptr_t* esp          = esp_base - tempcount - popframe_extra_args;
   intptr_t* sp           = (intptr_t *) (((intptr_t) (esp_base - callee_locals_count + callee_param_count - method->max_stack()- abi_scratch)) & -StackAlignmentInBytes);
-  intptr_t* sender_sp    = caller->sp() + (frame::abi_minframe_size - frame::abi_reg_args_size) / Interpreter::stackElementSize;
-  intptr_t* top_frame_sp = is_top_frame ? sp : sp + (frame::abi_minframe_size - frame::abi_reg_args_size) / Interpreter::stackElementSize;
+  intptr_t* sender_sp    = caller->sp() + (frame::parent_ijava_frame_abi_size - frame::top_ijava_frame_abi_size) / Interpreter::stackElementSize;
+  intptr_t* top_frame_sp = is_top_frame ? sp : sp + (frame::parent_ijava_frame_abi_size - frame::top_ijava_frame_abi_size) / Interpreter::stackElementSize;
 
   interpreter_frame->interpreter_frame_set_method(method);
   interpreter_frame->interpreter_frame_set_mirror(method->method_holder()->java_mirror());

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1830,7 +1830,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
   // Set up the arraycopy stub information.
   ArrayCopyStub* stub = op->stub();
-  const int frame_resize = frame::abi_reg_args_size - sizeof(frame::jit_abi); // C calls need larger frame.
+  const int frame_resize = frame::native_abi_reg_args_size - sizeof(frame::java_abi); // C calls need larger frame.
 
   // Always do stub if no type information is available. It's ok if
   // the known type isn't loaded since the code sanity checks

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,7 +153,7 @@ static int fpu_reg_save_offsets[FrameMap::nof_fpu_regs];
 static int frame_size_in_bytes = -1;
 
 static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
-  assert(frame_size_in_bytes > frame::abi_reg_args_size, "init");
+  assert(frame_size_in_bytes > frame::native_abi_reg_args_size, "init");
   sasm->set_frame_size(frame_size_in_bytes / BytesPerWord);
   int frame_size_in_slots = frame_size_in_bytes / sizeof(jint);
   OopMap* oop_map = new OopMap(frame_size_in_slots, 0);
@@ -241,7 +241,7 @@ static void restore_live_registers(StubAssembler* sasm, Register result1, Regist
 
 void Runtime1::initialize_pd() {
   int i;
-  int sp_offset = frame::abi_reg_args_size;
+  int sp_offset = frame::native_abi_reg_args_size;
 
   for (i = 0; i < FrameMap::nof_cpu_regs; i++) {
     Register r = as_Register(i);
@@ -487,9 +487,9 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
         __ mflr(R0);
         __ std(R0, _abi0(lr), R1_SP);
-        __ push_frame(frame::abi_reg_args_size, R0); // Empty dummy frame (no callee-save regs).
-        sasm->set_frame_size(frame::abi_reg_args_size / BytesPerWord);
-        OopMap* oop_map = new OopMap(frame::abi_reg_args_size / sizeof(jint), 0);
+        __ push_frame(frame::native_abi_reg_args_size, R0); // Empty dummy frame (no callee-save regs).
+        sasm->set_frame_size(frame::native_abi_reg_args_size / BytesPerWord);
+        OopMap* oop_map = new OopMap(frame::native_abi_reg_args_size / sizeof(jint), 0);
         int call_offset = __ call_RT(noreg, noreg,
                                      CAST_FROM_FN_PTR(address, SharedRuntime::register_finalizer), R3_ARG1);
         oop_maps = new OopMapSet();
@@ -732,9 +732,9 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         __ set_info("unimplemented entry", dont_gc_arguments);
         __ mflr(R0);
         __ std(R0, _abi0(lr), R1_SP);
-        __ push_frame(frame::abi_reg_args_size, R0); // empty dummy frame
-        sasm->set_frame_size(frame::abi_reg_args_size / BytesPerWord);
-        OopMap* oop_map = new OopMap(frame::abi_reg_args_size / sizeof(jint), 0);
+        __ push_frame(frame::native_abi_reg_args_size, R0); // empty dummy frame
+        sasm->set_frame_size(frame::native_abi_reg_args_size / BytesPerWord);
+        OopMap* oop_map = new OopMap(frame::native_abi_reg_args_size / sizeof(jint), 0);
 
         __ load_const_optimized(R4_ARG2, (int)id);
         int call_offset = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, unimplemented_entry), R4_ARG2);

--- a/src/hotspot/cpu/ppc/continuationEntry_ppc.hpp
+++ b/src/hotspot/cpu/ppc/continuationEntry_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 
 class ContinuationEntryPD {
   // This is needed to position the ContinuationEntry at the unextended sp of the entry frame
-  frame::abi_reg_args _abi;
+  frame::native_abi_reg_args _abi;
 };
 
 #endif // CPU_PPC_CONTINUATIONENTRY_PPC_HPP

--- a/src/hotspot/cpu/ppc/continuationFreezeThaw_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuationFreezeThaw_ppc.inline.hpp
@@ -130,7 +130,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //
 //     Caller on entry                                     New frame with resized Caller
 //
-//     | frame::abi_minframe    |                          |                        |
+//     | frame::java_abi        |                          |                        |
 //     |                        |<- FP of caller           | Caller's SP            |<- FP of caller
 //     ==========================                          ==========================
 //     | ijava_state            |                          | ijava_state            |
@@ -140,9 +140,9 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //     | :                      |                    |     | :      :               |
 //     | Pn                     |<- unext. SP        |     | :      Pn              |<- unext. SP
 //     |------------------------|   + metadata     overlap | :                      |   + metadata
-//     | frame::abi_minframe    |                    |     | Lm                     |
+//     | frame::java_abi        |                    |     | Lm                     |
 //     | (metadata_words_at_top)|<- SP == unext. SP  v     |------------------------|<- unextended SP of caller (1)
-//     ==========================   of caller      -----   | frame::abi_minframe    |
+//     ==========================   of caller      -----   | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- new SP of caller / FP of new frame
 //      overlap = stack_argsize(f)                         ==========================       ^
 //                + frame::metadata_words_at_top           | ijava_state            |       |
@@ -153,7 +153,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //                                                         | :                      |       |
 //                            |  Growth  |                 | Pi                     |       v
 //                            v          v                 |------------------------|      ---
-//                                                         | frame::abi_minframe    |
+//                                                         | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- unextended SP /
 //                                                         ==========================   SP of new frame
 // ### Compiled Caller: No Overlap
@@ -163,13 +163,13 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //
 //     Caller on entry                                     New frame with resized Caller
 //
-//     | frame::abi_minframe    |                          |                        |
+//     | frame::java_abi        |                          |                        |
 //     | (metadata_words_at_top)|<- FP of caller           | Caller's SP            |<- FP of caller
 //     ==========================                          ==========================
 //     |                        |                          |                        |
 //     |                        |                          |                        |
 //     |------------------------|                          |------------------------|
-//     | frame::abi_minframe    |                          | frame::abi_minframe    |
+//     | frame::java_abi        |                          | frame::java_abi        |
 //     | (metadata_words_at_top)|<- SP == unext. SP        | (metadata_words_at_top)|<- unext. SP of caller
 //     ==========================   of caller              |------------------------|
 //                                                         | L0 aka P0              |
@@ -177,7 +177,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //                                                         | :      Pn              |
 //      overlap = 0                                        | Lm                     |
 //                                                         |------------------------|
-//      f is the frame to be relocated on the heap         | frame::abi_minframe    |
+//      f is the frame to be relocated on the heap         | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- new SP of caller / FP of new frame
 //                                                         ==========================       ^
 //                                                         | ijava_state            |       |
@@ -188,7 +188,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //                                                         | :                      |       |
 //                                                         | Pi                     |       v
 //                                                         |------------------------|      ---
-//                                                         | frame::abi_minframe    |
+//                                                         | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- unextended SP /
 //                                                         ==========================   SP of new frame
 //
@@ -208,7 +208,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //
 //     Caller on entry                                     New frame with resized Caller
 //
-//     | frame::abi_minframe    |                          | frame::abi_minframe    |
+//     | frame::java_abi        |                          | frame::java_abi        |
 //     | (metadata_words_at_top)|<- FP of caller           | (metadata_words_at_top)|<- FP of caller
 //     ==========================                          ==========================
 //     | ijava_state            |                          | ijava_state            |
@@ -218,19 +218,19 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //     | :                      |                          | :                      |
 //     | Pn                     |<- unext. SP              | Pn                     |<- unext. SP
 //     |------------------------|   + metadata             |------------------------|   + metadata
-//     | frame::abi_minframe    |                          | frame::abi_minframe    |
+//     | frame::java_abi        |                          | frame::java_abi        |
 //     | (metadata_words_at_top)|<- SP == unext. SP        | (metadata_words_at_top)|<- unextended SP of caller (1)
 //     ==========================   of caller              |------------------------|
 //                                                         | Stack Args             |
 //      overlap = 0                                        | (if any)               |
 //                                                         |------------------------|
-//      f is the frame to be relocated on the heap         | frame::abi_minframe    |
+//      f is the frame to be relocated on the heap         | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- new SP of caller / FP of new frame
 //                                                         ==========================
 //                                                         |                        |
 //                             |  Growth  |                |                        |
 //                             v          v                |------------------------|
-//                                                         | frame::abi_minframe    |
+//                                                         | frame::java_abi        |
 //                                                         | (metadata_words_at_top)|<- SP == unext. SP of new frame
 //                                                         ==========================
 //
@@ -238,7 +238,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //
 //     Caller on entry                                     New frame with resized Caller
 //
-//     | frame::abi_minframe    |                          | frame::abi_minframe    |
+//     | frame::java_abi        |                          | frame::java_abi        |
 //     | (metadata_words_at_top)|<- FP of caller           | (metadata_words_at_top)|<- FP of caller
 //     ==========================                          ==========================
 //     |                        |                          |                        |
@@ -247,13 +247,13 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
 //     | Stack Args             |                     ^    | Stack Args             |
 //     | (if any)               |                     |    | (if any)               |
 //     |------------------------|                  overlap |------------------------|
-//     | frame::abi_minframe    |                     |    | frame::abi_minframe    |
+//     | frame::java_abi        |                     |    | frame::java_abi        |
 //     | (metadata_words_at_top)|<- SP == unext. SP   v    | (metadata_words_at_top)|<- SP == unext. SP of caller
 //     ==========================   of caller       -----  ==========================   / FP of new frame
 //                                                         |                        |
 //      overlap = stack_argsize(f)                         |                        |
 //                + frame::metadata_words_at_top           |------------------------|
-//                                                         | frame::abi_minframe    |
+//                                                         | frame::java_abi        |
 //      Where f is the frame to be relocated on the heap.  | (metadata_words_at_top)|<- SP == unext. SP of new frame
 //      See also StackChunkFrameStream::frame_size().      ==========================
 //
@@ -345,7 +345,7 @@ inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
 template <typename ConfigT>
 inline void Thaw<ConfigT>::patch_caller_links(intptr_t* sp, intptr_t* bottom) {
   for (intptr_t* callers_sp; sp < bottom; sp = callers_sp) {
-    address pc = (address)((frame::abi_minframe*) sp)->lr;
+    address pc = (address)((frame::java_abi*) sp)->lr;
     assert(pc != nullptr, "");
     // see ThawBase::patch_return() which gets called just before
     bool is_entry_frame = pc == StubRoutines::cont_returnBarrier() || pc == _cont.entryPC();
@@ -356,7 +356,7 @@ inline void Thaw<ConfigT>::patch_caller_links(intptr_t* sp, intptr_t* bottom) {
       callers_sp = sp + cb->frame_size();
     }
     // set the back link
-    ((frame::abi_minframe*) sp)->callers_sp = (intptr_t) callers_sp;
+    ((frame::java_abi*) sp)->callers_sp = (intptr_t) callers_sp;
   }
 }
 
@@ -375,29 +375,29 @@ inline frame ThawBase::new_entry_frame() {
 //
 //     |                      |                            Non-Interpreted |                      |
 //     |                      |<- bottom                   Caller          |----------------------|
-//     |----------------------|    ^                                       | frame::abi_minframe  |<- unextended SP
+//     |----------------------|    ^                                       | frame::java_abi      |<- unextended SP
 //     | L0 aka P0            |    |                                   --- ========================
 //     | :      :             |    |                                    ^  | L0 aka P0            |
 //     | :      Pn            |    |                                    |  | :      :             | Parameters do
 //     | :                    |    |                                    |  | :      Pn            | not overlap with
 //     | Lm                   |    |                                    |  | :                    | caller!
 //     |----------------------| `fsize`                                 |  | :                    |
-//     | frame::abi_minframe  |    |                                       | :                    |
+//     | frame::java_abi      |    |                                       | :                    |
 //     ========================    |                     `fsize` + padding | Lm                   |
 //     |                      |    |                                       |----------------------|
 //     | ijava_state          |    |                                    |  | Opt. Align. Padding  |
 //     |                      |    |                                    |  |----------------------|
-//     |----------------------|    |                                    |  | frame::abi_minframe  |<- new SP of caller
+//     |----------------------|    |                                    |  | frame::java_abi      |<- new SP of caller
 //     | L0 aka P0            |    |                                    |  ========================   / FP of new frame
 //     | :      :             |    |                                    |  |                      |   (aligned)
 //     | :      Pn            |<- unext. SP + metadata                  |  | ijava_state          |
 //     | :                    |    |                                    |  |                      |
 //     | Lm                   |    |                                    |  |----------------------|
 //     |----------------------|    v                                    |  | P0                   |
-//     | frame::abi_minframe  |<- SP / unextended SP                    |  | :                    |
+//     | frame::java_abi      |<- SP / unextended SP                    |  | :                    |
 //     ========================                                         |  | Pi                   |<- unextended SP + metadata
 //                                                                      |  |----------------------|
-//                                           | Growth |                 v  | frame::abi_minframe  |<- unextended SP / SP of new frame
+//                                           | Growth |                 v  | frame::java_abi      |<- unextended SP / SP of new frame
 //                                           v        v                --- ========================   (not yet aligned(1))
 //
 //
@@ -414,13 +414,13 @@ inline frame ThawBase::new_entry_frame() {
 //     | :                    |                            |            |  | :      :             |
 //     | Pn                   |<- unextended SP           overlap       |  | :      Pn            |<- unextended SP
 //     |----------------------|   + metadata_words_at_top  |            |  | :                    |   + metadata_words_at_top
-//     | frame::abi_minframe  |<- unextended SP            v            |  | :                    |   (unaligned)
+//     | frame::java_abi      |<- unextended SP            v            |  | :                    |   (unaligned)
 //     ========================   / SP of new frame       ---           |  | :                    |   of caller
 //                                (not yet aligned(1))                  |  | Lm                   |
 //                                                                `fsize`  |----------------------|
 //       overlap = stack_argsize(hf)                              + padding| Opt. Align. Padding  |
 //                 + frame::metadata_words_at_top                       |  |----------------------|
-//                                                                      |  | frame::abi_minframe  |<- new SP of caller
+//                                                                      |  | frame::java_abi      |<- new SP of caller
 //                                                                      |  ========================   / FP of new frame
 //                                                                      |  |                      |   (aligned)
 //                                  | Growth |                          |  | ijava_state          |
@@ -430,7 +430,7 @@ inline frame ThawBase::new_entry_frame() {
 //                                                                      |  | :                    |
 //                                                                      |  | Pi                   |<- unextended SP
 //                                                                      |  |----------------------|    + metadata_words_at_top
-//                                                                      v  | frame::abi_minframe  |<- unextended SP / SP of new frame
+//                                                                      v  | frame::java_abi      |<- unextended SP / SP of new frame
 //                                                                     --- ========================   (not yet aligned(1))
 //
 //
@@ -458,20 +458,20 @@ inline frame ThawBase::new_entry_frame() {
 //   g l  |----------------------|                     |                      |
 //   i e  | Stack Args           |                     |                      |
 //   n r  | (if any)             |                     |----------------------|
-//   a    |----------------------|                     | frame::abi_minframe  |
-//   l    | frame::abi_minframe  |<- unext. SP / SP    | (unused)             |<- unal.unext.SP
+//   a    |----------------------|                     | frame::java_abi      |
+//   l    | frame::java_abi      |<- unext. SP / SP    | (unused)             |<- unal.unext.SP
 //  - - - ======================== - - - - - - - - - - |----------------------|- - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //    N   |                      |                     | Opt. Align. Padding  |
 //    e   |                      |                     |----------------------|
 //    w   |----------------------|                     | Stack Args           |
-//        | frame::abi_minframe  |<- unext. SP / SP    | (if any)             |
+//        | frame::java_abi      |<- unext. SP / SP    | (if any)             |
 //    F   ========================                     |----------------------|
-//    r                                                | frame::abi_minframe  |<- caller's SP
+//    r                                                | frame::java_abi      |<- caller's SP
 //    a                                                ======================== / new frame's FP
 //    m                                                |                      |   (aligned)
 //    e                                                |                      |
 //                                                     |----------------------|
-//                                                     | frame::abi_minframe  |<- unext. SP / SP
+//                                                     | frame::java_abi      |<- unext. SP / SP
 //                                                     ========================
 //
 //  If the new frame is at the bottom just above the ContinuationEntry frame then the stackargs
@@ -576,8 +576,8 @@ inline void ThawBase::patch_pd(frame& f, const frame& caller) {
 //                                          - Note that unextended SP < SP
 //                                            is possible on ppc.
 //
-// | Minimal ABI          |                 | Minimal ABI          |                      | Minimal ABI          |
-// | (frame::abi_minframe)|                 | (frame::abi_minframe)|                      | (frame::abi_minframe)|
+// |                      |                 |                      |                      |                      |
+// | (frame::java_abi)    |                 | (frame::java_abi)    |                      | (frame::java_abi)    |
 // | 4 words              |                 | 4 words              |                      | 4 words              |
 // | Caller's SP          |<- FP of caller  | Caller's SP          |<- FP of caller       | Caller's SP          |<- FP of caller
 // ========================   (aligned)     ========================                      ========================
@@ -593,13 +593,13 @@ inline void ThawBase::patch_pd(frame& f, const frame& caller) {
 // | Reserved Expr. Stack |                 |----------------------|                      |----------------------|
 // |                      |                 | Opt. Alignm. Padding |                      | Opt. Alignm. Padding |
 // |                      |<- ConstMethod   |----------------------|                      |----------------------|
-// |----------------------|   ::_max_stack  | Minimal ABI          |                      | Minimal ABI          |
-// | Opt. Alignm. Padding |                 | (frame::abi_minframe)|                      | (frame::abi_minframe)|
+// |----------------------|   ::_max_stack  |                      |                      |                      |
+// | Opt. Alignm. Padding |                 | (frame::java_abi)    |                      | (frame::java_abi)    |
 // |----------------------|                 | 4 words              |                      | 4 words              |
 // | Large ABI            |                 | Caller's SP          |<- new SP of caller   | Caller's SP          |<- SP of caller /
 // | for C++ calls        |                 ========================   (aligned)          ========================   FP of callee
-// | (frame::abi_reg_args)|                                                               | frame::              |   (aligned)
-// |                      |                                                               | ijava_state          |
+// | (frame::             |                                                               | frame::              |   (aligned)
+// |  native_abi_reg_args)|                                                               | ijava_state          |
 // |                      |                                                               |                      |
 // |                      |                                                               |----------------------|
 // |                      |                                                               |                      |
@@ -615,8 +615,8 @@ inline void ThawBase::patch_pd(frame& f, const frame& caller) {
 //                     -------------------->              ------------------------>       |----------------------|
 //                     (ABI, expressions, locals)                                         | Large ABI            |
 //                                                                                        | for C++ calls        |
-//                                                                                        | (frame::abi_reg_args)|
-//                                                                                        |                      |
+//                                                                                        | (frame::             |
+//                                                                                        |  native_abi_reg_args)|
 //                                                |  Growth  |                            |                      |
 //                                                v          v                            |                      |
 //                                                                                        |                      |

--- a/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
@@ -107,7 +107,7 @@ inline void ContinuationHelper::Frame::patch_pc(const frame& f, address pc) {
 }
 
 //                     | Minimal ABI          |
-//                     | (frame::abi_minframe)|
+//                     | (frame::java_abi)    |
 //                     | 4 words              |
 //                     | Caller's SP          |<- FP of f's caller
 //                     |======================|
@@ -124,7 +124,7 @@ inline void ContinuationHelper::Frame::patch_pc(const frame& f, address pc) {
 //                     | SP alignment (opt.)  |
 //                     |----------------------|
 //                     | Minimal ABI          |
-//                     | (frame::abi_minframe)|
+//                     | (frame::java_abi)    |
 //                     | 4 words              |
 //                     | Caller's SP          |<- SP of f's caller / FP of f
 //                     |======================|
@@ -145,7 +145,7 @@ inline void ContinuationHelper::Frame::patch_pc(const frame& f, address pc) {
 //                     | SP alignment (opt.)  |
 //                     |----------------------|
 //                     | Minimal ABI          |
-//                     | (frame::abi_minframe)|
+//                     | (frame::java_abi)    |
 //                     | 4 words              |
 //                     | Caller's SP          |<- SP of f / FP of f's callee
 //                     |======================|

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    abi_minframe* sender_abi = (abi_minframe*) fp;
+    common_abi* sender_abi = (common_abi*) fp;
     intptr_t* sender_sp = (intptr_t*) fp;
     address   sender_pc = (address) sender_abi->lr;;
 
@@ -281,7 +281,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (sp() == 0 || (intptr_t(sp()) & (wordSize-1)) != 0) {
     return false;
   }
-  int min_frame_slots = (abi_minframe_size + ijava_state_size) / sizeof(intptr_t);
+  int min_frame_slots = (parent_ijava_frame_abi_size + ijava_state_size) / sizeof(intptr_t);
   if (fp() - min_frame_slots < sp()) {
     return false;
   }

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -62,16 +62,16 @@
   //            ...
   //            spill slot for FR
   //
-  //  ABI_48:
+  //  ABI_MINFRAME:
   //    0       caller's SP
   //    8       space for condition register (CR) for next call
   //    16      space for link register (LR) for next call
-  //    24      reserved
-  //    32      reserved
+  //    24      reserved (ABI_ELFv2 only)
+  //    32      reserved (ABI_ELFv2 only)
   //    40      space for TOC (=R2) register for next call
   //
   //  ABI_REG_ARGS:
-  //    0       [ABI_48]
+  //    0       [ABI_MINFRAME]
   //    48      CARG_1: spill slot for outgoing arg 1. used by next callee.
   //    ...     ...
   //    104     CARG_8: spill slot for outgoing arg 8. used by next callee.
@@ -82,11 +82,15 @@
   // C frame layout
   static const int alignment_in_bytes = 16;
 
-  // ABI_MINFRAME:
-  struct abi_minframe {
+  // Common ABI. On top of all frames, C and Java
+  struct common_abi {
     uint64_t callers_sp;
-    uint64_t cr;                                  //_16
+    uint64_t cr;
     uint64_t lr;
+  };
+
+  // ABI_MINFRAME. Used for native C frames.
+  struct native_abi_minframe : common_abi {
 #if !defined(ABI_ELFv2)
     uint64_t reserved1;                           //_16
     uint64_t reserved2;
@@ -96,11 +100,7 @@
     // aligned to frame::alignment_in_bytes (16)
   };
 
-  enum {
-    abi_minframe_size = sizeof(abi_minframe)
-  };
-
-  struct abi_reg_args : abi_minframe {
+  struct native_abi_reg_args : native_abi_minframe {
     uint64_t carg_1;
     uint64_t carg_2;                              //_16
     uint64_t carg_3;
@@ -113,13 +113,14 @@
   };
 
   enum {
-    abi_reg_args_size = sizeof(abi_reg_args)
+    native_abi_minframe_size = sizeof(native_abi_minframe),
+    native_abi_reg_args_size = sizeof(native_abi_reg_args)
   };
 
   #define _abi0(_component) \
-          (offset_of(frame::abi_reg_args, _component))
+          (offset_of(frame::native_abi_reg_args, _component))
 
-  struct abi_reg_args_spill : abi_reg_args {
+  struct native_abi_reg_args_spill : native_abi_reg_args {
     // additional spill slots
     uint64_t spill_ret;
     uint64_t spill_fret;                          //_16
@@ -127,11 +128,11 @@
   };
 
   enum {
-    abi_reg_args_spill_size = sizeof(abi_reg_args_spill)
+    native_abi_reg_args_spill_size = sizeof(native_abi_reg_args_spill)
   };
 
-  #define _abi_reg_args_spill(_component) \
-          (offset_of(frame::abi_reg_args_spill, _component))
+  #define _native_abi_reg_args_spill(_component) \
+          (offset_of(frame::native_abi_reg_args_spill, _component))
 
   // non-volatile GPRs:
 
@@ -186,6 +187,10 @@
 
   // Frame layout for the Java template interpreter on PPC64.
   //
+  // We differnetiate between TOP and PARENT frames.
+  // TOP frames allow for calling native C code.
+  // A TOP frame is trimmed to a PARENT frame when calling a Java method.
+  //
   // In these figures the stack grows upwards, while memory grows
   // downwards. Square brackets denote regions possibly larger than
   // single 64 bit slots.
@@ -227,20 +232,23 @@
   //            [outgoing arguments]
   //            [ENTRY_FRAME_LOCALS]
 
-  struct parent_ijava_frame_abi : abi_minframe {
+  // ABI for every Java frame, compiled and interpreted
+  struct java_abi : common_abi {
+    uint64_t toc;
   };
 
-  enum {
-    parent_ijava_frame_abi_size = sizeof(parent_ijava_frame_abi)
+  struct parent_ijava_frame_abi : java_abi {
   };
 
 #define _parent_ijava_frame_abi(_component) \
         (offset_of(frame::parent_ijava_frame_abi, _component))
 
-  struct top_ijava_frame_abi : abi_reg_args {
+  struct top_ijava_frame_abi : native_abi_reg_args {
   };
 
   enum {
+    java_abi_size = sizeof(java_abi),
+    parent_ijava_frame_abi_size = sizeof(parent_ijava_frame_abi),
     top_ijava_frame_abi_size = sizeof(top_ijava_frame_abi)
   };
 
@@ -318,18 +326,10 @@
   //          [in_preserve] added / removed by prolog / epilog
   //
 
-  // JIT_ABI (TOP and PARENT)
+  // For JIT frames we don't differentiate between TOP and PARENT frames.
+  // Runtime calls go through stubs which push a new frame.
 
-  struct jit_abi {
-    uint64_t callers_sp;
-    uint64_t cr;
-    uint64_t lr;
-    uint64_t toc;
-    // Nothing to add here!
-    // NOT ALIGNED to frame::alignment_in_bytes (16).
-  };
-
-  struct jit_out_preserve : jit_abi {
+  struct jit_out_preserve : java_abi {
     // Nothing to add here!
   };
 
@@ -380,8 +380,8 @@
   void set_offset_fp(int value) { assert_on_heap(); _offset_fp = value; }
 
   // Accessors for ABIs
-  inline abi_minframe* own_abi()     const { return (abi_minframe*) _sp; }
-  inline abi_minframe* callers_abi() const { return (abi_minframe*) _fp; }
+  inline common_abi* own_abi()     const { return (common_abi*) _sp; }
+  inline common_abi* callers_abi() const { return (common_abi*) _fp; }
 
  private:
 
@@ -429,14 +429,14 @@
     // normal return address is 1 bundle past PC
     pc_return_offset                       = 0,
     // size, in words, of frame metadata (e.g. pc and link)
-    metadata_words                         = sizeof(abi_minframe) >> LogBytesPerWord,
+    metadata_words                         = sizeof(java_abi) >> LogBytesPerWord,
     // size, in words, of metadata at frame bottom, i.e. it is not part of the
     // caller/callee overlap
     metadata_words_at_bottom               = 0,
     // size, in words, of frame metadata at the frame top, i.e. it is located
     // between a callee frame and its stack arguments, where it is part
     // of the caller/callee overlap
-    metadata_words_at_top                  = sizeof(abi_minframe) >> LogBytesPerWord,
+    metadata_words_at_top                  = sizeof(java_abi) >> LogBytesPerWord,
     // size, in words, of frame metadata at the frame top that needs
     // to be reserved for callee functions in the runtime
     frame_alignment                        = 16,

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_pre_barrier(MacroAssembler* masm
     int spill_slots = 3;
     if (preserve1 != noreg) { spill_slots++; }
     if (preserve2 != noreg) { spill_slots++; }
-    const int frame_size = align_up(frame::abi_reg_args_size + spill_slots * BytesPerWord, frame::alignment_in_bytes);
+    const int frame_size = align_up(frame::native_abi_reg_args_size + spill_slots * BytesPerWord, frame::alignment_in_bytes);
     Label filtered;
 
     // Is marking active?
@@ -98,7 +98,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_pre_barrier(MacroAssembler* masm
 void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
                                                              Register addr, Register count, Register preserve) {
   int spill_slots = (preserve != noreg) ? 1 : 0;
-  const int frame_size = align_up(frame::abi_reg_args_size + spill_slots * BytesPerWord, frame::alignment_in_bytes);
+  const int frame_size = align_up(frame::native_abi_reg_args_size + spill_slots * BytesPerWord, frame::alignment_in_bytes);
 
   __ save_LR_CR(R0);
   __ push_frame(frame_size, R0);

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -411,7 +411,7 @@ class ZSaveLiveRegisters {
 
     const int register_save_size = iterate_over_register_mask(ACTION_COUNT_ONLY) * BytesPerWord;
     _frame_size = align_up(register_save_size, frame::alignment_in_bytes)
-                  + frame::abi_reg_args_size;
+                  + frame::native_abi_reg_args_size;
 
     __ save_LR_CR(R0);
     __ push_frame(_frame_size, R0);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1157,7 +1157,7 @@ void InterpreterMacroAssembler::call_from_interpreter(Register Rtarget_method, R
   // to meet the abi scratch requirements.
   // The max_stack pointer will get restored by means of the GR_Lmax_stack local in
   // the return entry of the interpreter.
-  addi(Rscratch2, R15_esp, Interpreter::stackElementSize - frame::abi_reg_args_size);
+  addi(Rscratch2, R15_esp, Interpreter::stackElementSize - frame::top_ijava_frame_abi_size);
   clrrdi(Rscratch2, Rscratch2, exact_log2(frame::alignment_in_bytes)); // round towards smaller address
   resize_frame_absolute(Rscratch2, Rscratch2, R0);
 
@@ -2172,7 +2172,7 @@ void InterpreterMacroAssembler::save_interpreter_state(Register scratch) {
 void InterpreterMacroAssembler::restore_interpreter_state(Register scratch, bool bcp_and_mdx_only, bool restore_top_frame_sp) {
   ld(scratch, 0, R1_SP);
   if (restore_top_frame_sp) {
-    // After thawing the top frame of a continuation we reach here with frame::abi_minframe.
+    // After thawing the top frame of a continuation we reach here with frame::java_abi.
     // therefore we have to restore top_frame_sp before the assertion below.
     assert(!bcp_and_mdx_only, "chose other registers");
     Register tfsp = R18_locals;
@@ -2195,7 +2195,7 @@ void InterpreterMacroAssembler::restore_interpreter_state(Register scratch, bool
   {
     Label Lok;
     subf(R0, R1_SP, scratch);
-    cmpdi(CCR0, R0, frame::abi_reg_args_size + frame::ijava_state_size);
+    cmpdi(CCR0, R0, frame::top_ijava_frame_abi_size + frame::ijava_state_size);
     bge(CCR0, Lok);
     stop("frame too small (restore istate)");
     bind(Lok);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -730,7 +730,7 @@ void MacroAssembler::clobber_carg_stack_slots(Register tmp) {
 
   li(tmp, magic_number);
   for (int m = 0; m <= 7; m++) {
-    std(tmp, frame::abi_minframe_size + m * 8, R1_SP);
+    std(tmp, frame::native_abi_minframe_size + m * 8, R1_SP);
   }
 }
 
@@ -976,16 +976,16 @@ void MacroAssembler::push_frame(unsigned int bytes, Register tmp) {
   }
 }
 
-// Push a frame of size `bytes' plus abi_reg_args on top.
+// Push a frame of size `bytes' plus native_abi_reg_args on top.
 void MacroAssembler::push_frame_reg_args(unsigned int bytes, Register tmp) {
-  push_frame(bytes + frame::abi_reg_args_size, tmp);
+  push_frame(bytes + frame::native_abi_reg_args_size, tmp);
 }
 
 // Setup up a new C frame with a spill area for non-volatile GPRs and
 // additional space for local variables.
 void MacroAssembler::push_frame_reg_args_nonvolatiles(unsigned int bytes,
                                                       Register tmp) {
-  push_frame(bytes + frame::abi_reg_args_size + frame::spill_nonvolatiles_size, tmp);
+  push_frame(bytes + frame::native_abi_reg_args_size + frame::spill_nonvolatiles_size, tmp);
 }
 
 // Pop current C frame.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,7 +316,7 @@ class MacroAssembler: public Assembler {
   // Push a frame of size `bytes'. No abi space provided.
   void push_frame(unsigned int bytes, Register tmp);
 
-  // Push a frame of size `bytes' plus abi_reg_args on top.
+  // Push a frame of size `bytes' plus native_abi_reg_args on top.
   void push_frame_reg_args(unsigned int bytes, Register tmp);
 
   // Setup up a new C frame with a spill area for non-volatile GPRs and additional

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,11 +508,11 @@ void trace_method_handle_stub(const char* adaptername,
     ResourceMark rm;
     LogStream ls(lt);
     ls.print_cr("Registers:");
-    const int abi_offset = frame::abi_reg_args_size / 8;
+    const int abi_offset = frame::native_abi_reg_args_size / 8;
     for (int i = R3->encoding(); i <= R12->encoding(); i++) {
       Register r = as_Register(i);
       int count = i - R3->encoding();
-      // The registers are stored in reverse order on the stack (by save_volatile_gprs(R1_SP, abi_reg_args_size)).
+      // The registers are stored in reverse order on the stack (by save_volatile_gprs(R1_SP, native_abi_reg_args_size)).
       ls.print("%3s=" PTR_FORMAT, r->name(), saved_regs[abi_offset + count]);
       if ((count + 1) % 4 == 0) {
         ls.cr();

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3786,7 +3786,7 @@ frame %{
   // out_preserve_stack_slots for calls to C. Supports the var-args
   // backing area for register parms.
   //
-  varargs_C_out_slots_killed(((frame::abi_reg_args_size - frame::jit_out_preserve_size) / VMRegImpl::stack_slot_size));
+  varargs_C_out_slots_killed(((frame::native_abi_reg_args_size - frame::jit_out_preserve_size) / VMRegImpl::stack_slot_size));
 
   // The after-PROLOG location of the return address. Location of
   // return address specifies a type (REG or STACK) and a number

--- a/src/hotspot/cpu/ppc/runtime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/runtime_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ void OptoRuntime::generate_exception_blob() {
 
   address start = __ pc();
 
-  int frame_size_in_bytes = frame::abi_reg_args_size;
+  int frame_size_in_bytes = frame::native_abi_reg_args_size;
   OopMap* map = new OopMap(frame_size_in_bytes / sizeof(jint), 0);
 
   // Exception pc is 'return address' for stack walker.

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -272,7 +272,7 @@ OopMap* RegisterSaver::push_frame_reg_args_and_save_live_registers(MacroAssemble
                                                 : 0;
   const int register_save_size   = regstosave_num * reg_size + vsregstosave_num * vs_reg_size;
   const int frame_size_in_bytes  = align_up(register_save_size, frame::alignment_in_bytes)
-                                   + frame::abi_reg_args_size;
+                                   + frame::native_abi_reg_args_size;
 
   *out_frame_size_in_bytes       = frame_size_in_bytes;
   const int frame_size_in_slots  = frame_size_in_bytes / sizeof(jint);
@@ -790,7 +790,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
   int i;
   VMReg reg;
   // Leave room for C-compatible ABI_REG_ARGS.
-  int stk = (frame::abi_reg_args_size - frame::jit_out_preserve_size) / VMRegImpl::stack_slot_size;
+  int stk = (frame::native_abi_reg_args_size - frame::jit_out_preserve_size) / VMRegImpl::stack_slot_size;
   int arg = 0;
   int freg = 0;
 
@@ -1951,7 +1951,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
                                    int& compiled_entry_offset) {
   Register tmp = R10_ARG8;
 
-  const int framesize_bytes = (int)align_up((int)frame::abi_reg_args_size, frame::alignment_in_bytes);
+  const int framesize_bytes = (int)align_up((int)frame::native_abi_reg_args_size, frame::alignment_in_bytes);
   framesize_words = framesize_bytes / wordSize;
 
   address start = __ pc();
@@ -2478,7 +2478,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     // disallows any pending_exception.
 
     // Save argument registers and leave room for C-compatible ABI_REG_ARGS.
-    int frame_size = frame::abi_reg_args_size + align_up(total_c_args * wordSize, frame::alignment_in_bytes);
+    int frame_size = frame::native_abi_reg_args_size + align_up(total_c_args * wordSize, frame::alignment_in_bytes);
     __ mr(R11_scratch1, R1_SP);
     RegisterSaver::push_frame_and_save_argument_registers(masm, R12_scratch2, frame_size, total_c_args, out_regs, out_regs2);
 
@@ -2948,7 +2948,7 @@ void SharedRuntime::generate_deopt_blob() {
   OopMapSet *oop_maps = new OopMapSet();
 
   // size of ABI112 plus spill slots for R3_RET and F1_RET.
-  const int frame_size_in_bytes = frame::abi_reg_args_spill_size;
+  const int frame_size_in_bytes = frame::native_abi_reg_args_spill_size;
   const int frame_size_in_slots = frame_size_in_bytes / sizeof(jint);
   int first_frame_size_in_bytes = 0; // frame size of "unpack frame" for call to fetch_unroll_info.
 
@@ -3110,8 +3110,8 @@ void SharedRuntime::generate_deopt_blob() {
   // ...).
 
   // Spill live volatile registers since we'll do a call.
-  __ std( R3_RET, _abi_reg_args_spill(spill_ret),  R1_SP);
-  __ stfd(F1_RET, _abi_reg_args_spill(spill_fret), R1_SP);
+  __ std( R3_RET, _native_abi_reg_args_spill(spill_ret),  R1_SP);
+  __ stfd(F1_RET, _native_abi_reg_args_spill(spill_fret), R1_SP);
 
   // Let the unpacker layout information in the skeletal frames just
   // allocated.
@@ -3123,8 +3123,8 @@ void SharedRuntime::generate_deopt_blob() {
   __ reset_last_Java_frame();
 
   // Restore the volatiles saved above.
-  __ ld( R3_RET, _abi_reg_args_spill(spill_ret),  R1_SP);
-  __ lfd(F1_RET, _abi_reg_args_spill(spill_fret), R1_SP);
+  __ ld( R3_RET, _native_abi_reg_args_spill(spill_ret),  R1_SP);
+  __ lfd(F1_RET, _native_abi_reg_args_spill(spill_fret), R1_SP);
 
   // Pop the unpack frame.
   __ pop_frame();
@@ -3170,7 +3170,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   Register r_return_pc      = R27_tmp7;
 
   OopMapSet* oop_maps = new OopMapSet();
-  int frame_size_in_bytes = frame::abi_reg_args_size;
+  int frame_size_in_bytes = frame::native_abi_reg_args_size;
   OopMap* map = new OopMap(frame_size_in_bytes / sizeof(jint), 0);
 
   // stack: (deoptee, optional i2c, caller_of_deoptee, ...).

--- a/src/hotspot/cpu/ppc/stackChunkFrameStream_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/stackChunkFrameStream_ppc.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,14 +54,14 @@ inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
 template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   assert(!is_done(), "");
-  return (address)((frame::abi_minframe*) _sp)->lr;
+  return (address)((frame::common_abi*) _sp)->lr;
 }
 
 template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   // See FreezeBase::patch_pd() and frame::setup()
   assert((frame_kind == ChunkFrames::Mixed && is_interpreted()), "");
-  intptr_t* fp_addr = (intptr_t*)&((frame::abi_minframe*)_sp)->callers_sp;
+  intptr_t* fp_addr = (intptr_t*)&((frame::common_abi*)_sp)->callers_sp;
   assert(*(intptr_t**)fp_addr != nullptr, "");
   // derelativize
   return fp_addr + *fp_addr;

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,8 +91,8 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ function_entry();
 
     // some sanity checks
-    assert((sizeof(frame::abi_minframe) % 16) == 0,           "unaligned");
-    assert((sizeof(frame::abi_reg_args) % 16) == 0,           "unaligned");
+    assert((sizeof(frame::native_abi_minframe) % 16) == 0,    "unaligned");
+    assert((sizeof(frame::native_abi_reg_args) % 16) == 0,    "unaligned");
     assert((sizeof(frame::spill_nonvolatiles) % 16) == 0,     "unaligned");
     assert((sizeof(frame::parent_ijava_frame_abi) % 16) == 0, "unaligned");
     assert((sizeof(frame::entry_frame_locals) % 16) == 0,     "unaligned");
@@ -540,7 +540,7 @@ class StubGenerator: public StubCodeGenerator {
     MacroAssembler* masm = new MacroAssembler(&code);
 
     OopMapSet* oop_maps  = new OopMapSet();
-    int frame_size_in_bytes = frame::abi_reg_args_size;
+    int frame_size_in_bytes = frame::native_abi_reg_args_size;
     OopMap* map = new OopMap(frame_size_in_bytes / sizeof(jint), 0);
 
     address start = __ pc();
@@ -4553,7 +4553,7 @@ class StubGenerator: public StubCodeGenerator {
     __ mtctr(tmp1); __ bctr();
     __ bind(thaw_success);
 
-    __ addi(R3_RET, R3_RET, frame::abi_reg_args_size); // Large abi required for C++ calls.
+    __ addi(R3_RET, R3_RET, frame::native_abi_reg_args_size); // Large abi required for C++ calls.
     __ neg(R3_RET, R3_RET);
     // align down resulting in a smaller negative offset
     __ clrrdi(R3_RET, R3_RET, exact_log2(frame::alignment_in_bytes));
@@ -4617,7 +4617,7 @@ class StubGenerator: public StubCodeGenerator {
     Register tmp1 = R10_ARG8;
     Register tmp2 = R9_ARG7;
 
-    int framesize = frame::abi_reg_args_size / VMRegImpl::stack_slot_size;
+    int framesize = frame::native_abi_reg_args_size / VMRegImpl::stack_slot_size;
     address start = __ pc();
     __ mflr(tmp1);
     __ std(tmp1, _abi0(lr), R1_SP);  // save return pc

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -972,10 +972,10 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call, Regist
   }
 
   // Compute top frame size.
-  __ addi(Rtop_frame_size, Rtop_frame_size, frame::abi_reg_args_size + frame::ijava_state_size);
+  __ addi(Rtop_frame_size, Rtop_frame_size, frame::top_ijava_frame_abi_size + frame::ijava_state_size);
 
   // Cut back area between esp and max_stack.
-  __ addi(Rparent_frame_resize, Rparent_frame_resize, frame::abi_minframe_size - Interpreter::stackElementSize);
+  __ addi(Rparent_frame_resize, Rparent_frame_resize, frame::parent_ijava_frame_abi_size - Interpreter::stackElementSize);
 
   __ round_to(Rtop_frame_size, frame::alignment_in_bytes);
   __ round_to(Rparent_frame_resize, frame::alignment_in_bytes);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -486,7 +486,7 @@ FreezeBase::FreezeBase(JavaThread* thread, ContinuationWrapper& cont, intptr_t* 
 #if !defined(PPC64) || defined(ZERO)
   static const int doYield_stub_frame_size = frame::metadata_words;
 #else
-  static const int doYield_stub_frame_size = frame::abi_reg_args_size >> LogBytesPerWord;
+  static const int doYield_stub_frame_size = frame::native_abi_reg_args_size >> LogBytesPerWord;
 #endif
   assert(SharedRuntime::cont_doYield_stub()->frame_size() == doYield_stub_frame_size, "");
 


### PR DESCRIPTION
I would like to backport this change in order to bring my VThread changes to jdk20u. My changes depend on this one.

Much of the line count of this change is from renaming. However, this change isn't 'just' a renaming. The core of the changes come from `frame_ppc.hpp` with the removal of `jit_abi`. Both Java and C frames had their own C-frame structure and Java's was not completely correct for the big endian ABI. These changes point both Java and C frame structures to a common ABI.

The backport did not apply cleanly--but only due to differences in the copyright header years.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305668](https://bugs.openjdk.org/browse/JDK-8305668): PPC: Non-Top Interpreted frames should be independent of ABI_ELFv2


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/83.diff">https://git.openjdk.org/jdk20u/pull/83.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/83#issuecomment-1563163303)