### PR TITLE
8309032: jpackage does not work for module projects unless --module-path is specified

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -62,10 +62,6 @@ final class LauncherData {
         return qualifiedClassName;
     }
 
-    boolean isClassNameFromMainJar() {
-        return jarMainClass != null;
-    }
-
     String packageName() {
         int sepIdx = qualifiedClassName.lastIndexOf('.');
         if (sepIdx < 0) {
@@ -215,7 +211,6 @@ final class LauncherData {
                 if (attrs != null) {
                     launcherData.qualifiedClassName = attrs.getValue(
                             Attributes.Name.MAIN_CLASS);
-                    launcherData.jarMainClass = launcherData.qualifiedClassName;
                 }
             }
         }
@@ -352,7 +347,7 @@ final class LauncherData {
             // of `release` file.
 
             final Path releaseFile;
-            if (!OperatingSystem.isMacOS()) {
+            if (!Platform.isMac()) {
                 releaseFile = cookedRuntime.resolve("release");
             } else {
                 // On Mac `cookedRuntime` can be runtime root or runtime home.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -309,7 +309,6 @@ final class LauncherData {
     }
 
     private String qualifiedClassName;
-    private String jarMainClass;
     private Path mainJarName;
     private List<Path> classPath;
     private List<Path> modulePath;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -24,8 +24,6 @@
  */
 package jdk.jpackage.internal;
 
-import jdk.internal.util.OperatingSystem;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;


### PR DESCRIPTION
Fixes an error when trying to add additional launchers in jpackage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032): jpackage does not work for module projects unless --module-path is specified (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20u.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jdk20u.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20u/pull/86.diff">https://git.openjdk.org/jdk20u/pull/86.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk20u/pull/86#issuecomment-1643680175)